### PR TITLE
feat: Complete Phase 1 - Controller rename, phase handling, and concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ go.work.sum
 # .idea/
 # .vscode/
 .claude/
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= quay.io/konveyor/kubevirt-datamover-controller:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -9,10 +9,22 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # CONTAINER_TOOL defines the container tool to be used for building images.
-# Be aware that the target commands are only tested with Docker which is
-# scaffolded by default. However, you might want to replace it to use other
-# tools. (i.e. podman)
-CONTAINER_TOOL ?= docker
+# By default, this Makefile uses docker, as the target commands have been tested primarily with it.
+# However, if docker is not available, the Makefile will attempt to use podman if it's installed.
+# You may also set CONTAINER_TOOL directly as an environment variable to specify a different tool.
+# If neither docker nor podman is found, or if the specified tool is unavailable, the Makefile will exit with an error.
+
+# Set CONTAINER_TOOL to Docker or Podman if not already defined by the user
+CONTAINER_TOOL ?= $(shell \
+  if command -v docker >/dev/null 2>&1; then echo docker; \
+  elif command -v podman >/dev/null 2>&1; then echo podman; \
+  else echo ""; \
+  fi \
+)
+ifeq ($(shell command -v $(CONTAINER_TOOL) >/dev/null 2>&1 && echo found),)
+  $(error The selected container tool '$(CONTAINER_TOOL)' is not available on this system. Please install it or choose a different tool.)
+endif
+$(info Using Container Tool: $(CONTAINER_TOOL))
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,230 @@
-# kubevirt-datamover-controller
+# KubeVirt Datamover Controller
+
+This project provides a Kubernetes controller for handling incremental qcow2-based VM backups using KubeVirt/libvirt Changed Block Tracking (CBT) instead of CSI snapshots.
+
+## Current Implementation Status
+
+**Phase 1: Controller Scaffolding**
+- [x] Controller watching DataUpload CRs
+- [x] Filter for `Spec.DataMover == "kubevirt"`
+- [x] Phase-based reconciliation logic (New, Accepted, Prepared, InProgress, Canceling)
+- [x] MaxConcurrentReconciles configuration via CLI flag
+- [x] RBAC manifests generated
+
+**Phase 2: VMBT/VMB Creation (In Development)**
+- [ ] Extract VirtualMachine reference from DataUpload annotation
+- [ ] Create temporary PVC for backup output
+- [ ] Create/update VirtualMachineBackupTracker (VMBT)
+- [ ] Create VirtualMachineBackup (VMB) CR
+- [ ] Monitor VMB status until completion
+
+**Phase 3: Write to BSL (Pending)**
+- [ ] Launch datamover pod with temp PVC mount and BSL credentials
+- [ ] Upload qcow2 files to object storage
+- [ ] Create/update checkpoint index.json
+
+**Phase 4: Read from BSL (Pending)**
+- [ ] Query checkpoint index before backup
+- [ ] Validate checkpoint chain
+- [ ] Handle missing/invalid checkpoints
+
+**Phase 5: Cleanup & Completion (Pending)**
+- [ ] Delete temporary PVC
+- [ ] Update DataUpload status to Completed
+
+## Design Overview
+
+This controller enables **incremental qcow2-based VM backups** using KubeVirt/libvirt tooling instead of CSI snapshots:
+
+| Aspect | CSI Approach | KubeVirt qcow2 Approach |
+|--------|--------------|-------------------------|
+| Layer | Storage (CSI driver) | Hypervisor (QEMU/libvirt) |
+| Snapshot mechanism | CSI VolumeSnapshot | VirtualMachineBackup CR |
+| Incremental | Kopia deduplication (scans whole volume) | True block-level CBT (only changed blocks) |
+| Data mover | Velero node-agent + kopia | This controller + qemu-img |
+| VM awareness | None (just sees PVC) | Full (knows it's a VM disk) |
+
+For full design details, see the [OADP KubeVirt Datamover Design Document](https://github.com/openshift/oadp-operator/blob/oadp-dev/docs/design/kubevirt-datamover.md).
+
+## Prerequisites
+
+- OpenShift cluster with OADP operator installed
+- KubeVirt with Changed Block Tracking (CBT) enabled
+- Virtual machines with `status.ChangedBlockTracking: Enabled`
+- oc CLI configured to access the cluster
+
+## Deployment and Testing
+
+### 1. Verify OADP Setup
+
+Before deploying the controller, ensure OADP is properly configured:
+
+```bash
+# Check OADP operator is installed
+oc get csv -n openshift-adp | grep oadp
+
+# Verify DataProtectionApplication (DPA) is configured
+oc get dpa -n openshift-adp
+
+# Check BackupStorageLocation is ready
+oc get bsl -n openshift-adp
+```
+
+### 2. Deploy the Controller
+
+#### Option A: Run Locally (Development)
+```bash
+# Install CRDs to the cluster (if any)
+make install
+
+# Run controller locally (recommended for testing)
+make run
+```
+
+#### Option B: Deploy to OpenShift Cluster
+```bash
+# Build and deploy the controller
+make docker-build docker-push IMG=<your-registry>/kubevirt-datamover-controller:latest
+make deploy IMG=<your-registry>/kubevirt-datamover-controller:latest
+
+# Check deployment status
+oc get pods -n kubevirt-datamover-system
+```
+
+#### Option C: Deploy to ttl.sh (Temporary Testing)
+```bash
+# Build for amd64 and push to ttl.sh (expires in 1 hour)
+docker build --platform linux/amd64 -t ttl.sh/kubevirt-datamover-controller:1h .
+docker push ttl.sh/kubevirt-datamover-controller:1h
+
+# Deploy using the ttl.sh image
+make deploy IMG=ttl.sh/kubevirt-datamover-controller:1h
+
+# Check deployment
+oc get pods -n kubevirt-datamover-system
+```
+
+### 3. Testing with DataUpload Resources
+
+The controller watches Velero DataUpload resources where `spec.datamover: kubevirt`.
+
+**Note**: Currently, Velero's built-in DataUpload controller also processes these resources. Upstream changes are required for Velero to skip reconciling when `spec.datamover` is set to an external value.
+
+#### Create a Test DataUpload
+
+```yaml
+apiVersion: velero.io/v2alpha1
+kind: DataUpload
+metadata:
+  name: test-kubevirt-du
+  namespace: openshift-adp
+spec:
+  datamover: kubevirt
+  snapshotType: kubevirt
+  sourceNamespace: my-vm-namespace
+  operationTimeout: 4h0m0s
+  csiSnapshot:
+    volumeSnapshot: ""
+    storageClass: ""
+    snapshotClass: ""
+  backupStorageLocation: default
+  sourceTargetPVC:
+    namespace: my-vm-namespace
+    name: my-vm-pvc
+```
+
+#### Monitor Controller Activity
+
+```bash
+# Watch controller logs
+oc logs -f -n kubevirt-datamover-system deployment/kubevirt-datamover-controller-manager
+
+# Watch DataUpload status
+oc get datauploads -n openshift-adp -w
+
+# Check DataUpload details
+oc get dataupload test-kubevirt-du -n openshift-adp -o yaml
+```
+
+### 4. Configuration Options
+
+The controller supports the following CLI flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--metrics-bind-address` | `0` | Address for metrics endpoint (`:8443` for HTTPS, `:8080` for HTTP) |
+| `--health-probe-bind-address` | `:8081` | Address for health probe endpoint |
+| `--leader-elect` | `false` | Enable leader election for HA |
+| `--max-concurrent-reconciles` | `3` | Maximum concurrent DataUpload reconciliations |
+| `--metrics-secure` | `true` | Serve metrics via HTTPS |
+
+### 5. Troubleshooting
+
+#### Controller Pod Not Starting
+```bash
+# Check pod status
+oc describe pod -n kubevirt-datamover-system -l control-plane=controller-manager
+
+# Check events
+oc get events -n kubevirt-datamover-system --sort-by='.lastTimestamp'
+```
+
+#### DataUpload Not Being Processed
+```bash
+# Verify datamover field is set correctly (lowercase!)
+oc get dataupload <name> -n openshift-adp -o jsonpath='{.spec.datamover}'
+
+# Check controller is watching
+oc logs -n kubevirt-datamover-system deployment/kubevirt-datamover-controller-manager | grep -i kubevirt
+```
+
+#### Architecture Mismatch (Exec Format Error)
+If running on an amd64 cluster but built on arm64 Mac:
+```bash
+# Rebuild with correct platform
+docker build --platform linux/amd64 -t <image> .
+docker push <image>
+
+# Use unique tag to avoid cached images
+docker build --platform linux/amd64 -t ttl.sh/kubevirt-datamover-controller:amd64-$(date +%s) .
+```
+
+### 6. Development Commands
+
+```bash
+# Run tests
+make test
+
+# Build locally
+make build
+
+# Generate manifests after API changes
+make manifests generate
+
+# Format and lint code
+make fmt vet lint
+
+# Run locally against cluster
+make run
+```
+
+## Kubebuilder
+
+The project was generated using kubebuilder version `v4.6.0`, running the following commands:
+```sh
+kubebuilder init \
+    --plugins go.kubebuilder.io/v4 \
+    --project-version 3 \
+    --project-name=kubevirt-datamover-controller \
+    --repo=github.com/migtools/kubevirt-datamover-controller \
+    --domain=openshift.io
+
+# Note: This controller watches Velero's DataUpload CRD rather than defining its own
+```
+
+## Related Resources
+
+- [OADP Operator](https://github.com/openshift/oadp-operator)
+- [KubeVirt Incremental Backup VEP](https://github.com/kubevirt/enhancements/blob/main/veps/sig-storage/incremental-backup.md)
+- [Velero](https://velero.io/)
+- [OADP Project Board](https://github.com/orgs/migtools/projects/7/views/20)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -180,13 +180,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Setup DataUpload controller
-	if err = (&controller.DataUploadReconciler{
+	// Setup KubeVirt DataUpload controller
+	if err = (&controller.KubeVirtDataUploadReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("DataUpload"),
+		Log:    ctrl.Log.WithName("controllers").WithName("KubeVirtDataUpload"),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "DataUpload")
+		setupLog.Error(err, "unable to create controller", "controller", "KubeVirtDataUpload")
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,6 +63,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var maxConcurrentReconciles int
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -81,6 +82,8 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 3,
+		"Maximum number of concurrent reconciles for the KubeVirt DataUpload controller")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -182,9 +185,10 @@ func main() {
 
 	// Setup KubeVirt DataUpload controller
 	if err = (&controller.KubeVirtDataUploadReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("KubeVirtDataUpload"),
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Log:                     ctrl.Log.WithName("controllers").WithName("KubeVirtDataUpload"),
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeVirtDataUpload")
 		os.Exit(1)

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: kubevirt-datamover-controller-system
+namespace: kubevirt-datamover-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: kubevirt-datamover-controller-
+namePrefix: kubevirt-datamover-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -34,8 +34,8 @@ const (
 	DataMoverKubeVirt = "kubevirt"
 )
 
-// DataUploadReconciler reconciles DataUpload objects where Spec.DataMover is "kubevirt"
-type DataUploadReconciler struct {
+// KubeVirtDataUploadReconciler reconciles DataUpload objects where Spec.DataMover is "kubevirt"
+type KubeVirtDataUploadReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 	Log    logr.Logger
@@ -48,7 +48,7 @@ type DataUploadReconciler struct {
 // +kubebuilder:rbac:groups=velero.io,resources=datauploads/status,verbs=get;update;patch
 
 // Reconcile handles DataUpload resources where Spec.DataMover is "kubevirt"
-func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *KubeVirtDataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	// Fetch the DataUpload
@@ -80,7 +80,7 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 }
 
 // SetupWithManager sets up the controller with the Manager
-func (r *DataUploadReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *KubeVirtDataUploadReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&velerov2alpha1.DataUpload{}).
 		WithEventFilter(r.filterKubeVirtDataMover()).
@@ -90,7 +90,7 @@ func (r *DataUploadReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // filterKubeVirtDataMover returns a predicate that filters for DataUploads
 // where Spec.DataMover is "kubevirt"
-func (r *DataUploadReconciler) filterKubeVirtDataMover() predicate.Predicate {
+func (r *KubeVirtDataUploadReconciler) filterKubeVirtDataMover() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		du, ok := obj.(*velerov2alpha1.DataUpload)
 		if !ok {

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -200,14 +200,15 @@ func (r *KubeVirtDataUploadReconciler) handleCanceling(ctx context.Context, logg
 }
 
 // updatePhase updates the DataUpload phase and status message
+// Uses Update instead of Status().Patch() to match Velero's approach,
+// which works regardless of whether the CRD has status subresource enabled
 func (r *KubeVirtDataUploadReconciler) updatePhase(ctx context.Context, du *velerov2alpha1.DataUpload, phase velerov2alpha1.DataUploadPhase, message string) error {
 	logger := log.FromContext(ctx)
 
-	original := du.DeepCopy()
 	du.Status.Phase = phase
 	du.Status.Message = message
 
-	if err := r.Status().Patch(ctx, du, client.MergeFrom(original)); err != nil {
+	if err := r.Update(ctx, du); err != nil {
 		logger.Error(err, "Failed to update DataUpload phase",
 			"dataUpload", du.Name,
 			"phase", phase)

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -19,12 +19,14 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -32,6 +34,9 @@ import (
 const (
 	// DataMoverKubeVirt is the datamover value that indicates this controller should handle the DataUpload
 	DataMoverKubeVirt = "kubevirt"
+
+	// DefaultMaxConcurrentReconciles is the default number of concurrent reconciles
+	DefaultMaxConcurrentReconciles = 3
 )
 
 // KubeVirtDataUploadReconciler reconciles DataUpload objects where Spec.DataMover is "kubevirt"
@@ -42,6 +47,9 @@ type KubeVirtDataUploadReconciler struct {
 
 	// OADPNamespace is the namespace where OADP and Velero resources are located
 	OADPNamespace string
+
+	// MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run
+	MaxConcurrentReconciles int
 }
 
 // +kubebuilder:rbac:groups=velero.io,resources=datauploads,verbs=get;list;watch;update;patch
@@ -70,20 +78,163 @@ func (r *KubeVirtDataUploadReconciler) Reconcile(ctx context.Context, req ctrl.R
 		"dataUpload", req.NamespacedName,
 		"phase", dataUpload.Status.Phase)
 
-	// TODO: Implement reconciliation logic
-	// Phase 2: VMBT/VMB creation
-	// Phase 3: Write to BSL (datamover pod)
-	// Phase 4: Read from BSL (checkpoint lookup)
-	// Phase 5: Cleanup & completion
+	// Handle based on current phase
+	switch dataUpload.Status.Phase {
+	case "", velerov2alpha1.DataUploadPhaseNew:
+		return r.handleNew(ctx, logger, dataUpload)
+
+	case velerov2alpha1.DataUploadPhaseAccepted:
+		return r.handleAccepted(ctx, logger, dataUpload)
+
+	case velerov2alpha1.DataUploadPhasePrepared:
+		return r.handlePrepared(ctx, logger, dataUpload)
+
+	case velerov2alpha1.DataUploadPhaseInProgress:
+		return r.handleInProgress(ctx, logger, dataUpload)
+
+	case velerov2alpha1.DataUploadPhaseCanceling:
+		return r.handleCanceling(ctx, logger, dataUpload)
+
+	case velerov2alpha1.DataUploadPhaseCompleted,
+		velerov2alpha1.DataUploadPhaseFailed,
+		velerov2alpha1.DataUploadPhaseCanceled:
+		// Terminal states - nothing to do
+		logger.V(1).Info("DataUpload is in terminal state", "phase", dataUpload.Status.Phase)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Info("Unknown DataUpload phase", "phase", dataUpload.Status.Phase)
+		return ctrl.Result{}, nil
+	}
+}
+
+// handleNew processes DataUploads in New phase
+// Validates prerequisites and transitions to Accepted
+func (r *KubeVirtDataUploadReconciler) handleNew(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload) (ctrl.Result, error) {
+	logger.Info("Handling New phase DataUpload")
+
+	// TODO Phase 2: Validate prerequisites
+	// - Check VM annotation exists
+	// - Validate VM is running
+	// - Check CBT is enabled on VM
+
+	// Transition to Accepted phase
+	if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseAccepted, "DataUpload accepted by kubevirt datamover"); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// handleAccepted processes DataUploads in Accepted phase
+// Creates VMBT/VMB and transitions to Prepared when ready
+func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload) (ctrl.Result, error) {
+	logger.Info("Handling Accepted phase DataUpload")
+
+	// TODO Phase 2: VMBT/VMB Creation
+	// - Extract VirtualMachine reference from annotation
+	// - Query BSL for latest checkpoint
+	// - Create/update VirtualMachineBackupTracker
+	// - Create VirtualMachineBackup CR
+	// - Create temporary PVC for backup output
+
+	// TODO: Transition to Prepared when VMB is ready
+	// For now, just log and return
+	logger.Info("VMBT/VMB creation not yet implemented")
 
 	return ctrl.Result{}, nil
 }
 
+// handlePrepared processes DataUploads in Prepared phase
+// Launches datamover pod and transitions to InProgress
+func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload) (ctrl.Result, error) {
+	logger.Info("Handling Prepared phase DataUpload")
+
+	// TODO Phase 3: Launch datamover pod
+	// - Create pod with temp PVC mount and BSL credentials
+	// - Pod uploads qcow2 files to object storage
+
+	// Transition to InProgress
+	if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseInProgress, "Datamover pod launched"); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// handleInProgress processes DataUploads in InProgress phase
+// Monitors datamover pod and transitions to Completed/Failed
+func (r *KubeVirtDataUploadReconciler) handleInProgress(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload) (ctrl.Result, error) {
+	logger.Info("Handling InProgress phase DataUpload")
+
+	// TODO Phase 3: Monitor datamover pod
+	// - Check pod status
+	// - On success: update index.json, create manifests, transition to Completed
+	// - On failure: transition to Failed
+
+	// TODO Phase 5: Cleanup
+	// - Delete temporary PVC
+	// - Optionally delete VMB
+
+	logger.Info("Datamover pod monitoring not yet implemented")
+
+	return ctrl.Result{}, nil
+}
+
+// handleCanceling processes DataUploads in Canceling phase
+// Cleans up resources and transitions to Canceled
+func (r *KubeVirtDataUploadReconciler) handleCanceling(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload) (ctrl.Result, error) {
+	logger.Info("Handling Canceling phase DataUpload")
+
+	// TODO: Cancel in-progress operations
+	// - Delete datamover pod if running
+	// - Delete VMB if exists
+	// - Delete temporary PVC
+	// - Transition to Canceled
+
+	if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseCanceled, "DataUpload canceled"); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// updatePhase updates the DataUpload phase and status message
+func (r *KubeVirtDataUploadReconciler) updatePhase(ctx context.Context, du *velerov2alpha1.DataUpload, phase velerov2alpha1.DataUploadPhase, message string) error {
+	logger := log.FromContext(ctx)
+
+	original := du.DeepCopy()
+	du.Status.Phase = phase
+	du.Status.Message = message
+
+	if err := r.Status().Patch(ctx, du, client.MergeFrom(original)); err != nil {
+		logger.Error(err, "Failed to update DataUpload phase",
+			"dataUpload", du.Name,
+			"phase", phase)
+		return fmt.Errorf("failed to update DataUpload phase to %s: %w", phase, err)
+	}
+
+	logger.Info("Updated DataUpload phase",
+		"dataUpload", du.Name,
+		"phase", phase,
+		"message", message)
+
+	return nil
+}
+
 // SetupWithManager sets up the controller with the Manager
 func (r *KubeVirtDataUploadReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	maxConcurrent := r.MaxConcurrentReconciles
+	if maxConcurrent <= 0 {
+		maxConcurrent = DefaultMaxConcurrentReconciles
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&velerov2alpha1.DataUpload{}).
 		WithEventFilter(r.filterKubeVirtDataMover()).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrent,
+		}).
 		Named("kubevirt-dataupload").
 		Complete(r)
 }

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -1,0 +1,499 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcile(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name            string
+		dataUpload      *velerov2alpha1.DataUpload
+		expectedRequeue bool
+		expectedPhase   velerov2alpha1.DataUploadPhase
+		expectError     bool
+	}{
+		{
+			name: "skip non-kubevirt datamover",
+			dataUpload: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover: "velero",
+				},
+			},
+			expectedRequeue: false,
+			expectedPhase:   "",
+			expectError:     false,
+		},
+		{
+			name: "new phase transitions to accepted",
+			dataUpload: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover: DataMoverKubeVirt,
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: velerov2alpha1.DataUploadPhaseNew,
+				},
+			},
+			expectedRequeue: true,
+			expectedPhase:   velerov2alpha1.DataUploadPhaseAccepted,
+			expectError:     false,
+		},
+		{
+			name: "empty phase transitions to accepted",
+			dataUpload: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover: DataMoverKubeVirt,
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: "",
+				},
+			},
+			expectedRequeue: true,
+			expectedPhase:   velerov2alpha1.DataUploadPhaseAccepted,
+			expectError:     false,
+		},
+		{
+			name: "completed phase is terminal - no action",
+			dataUpload: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover: DataMoverKubeVirt,
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: velerov2alpha1.DataUploadPhaseCompleted,
+				},
+			},
+			expectedRequeue: false,
+			expectedPhase:   velerov2alpha1.DataUploadPhaseCompleted,
+			expectError:     false,
+		},
+		{
+			name: "failed phase is terminal - no action",
+			dataUpload: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover: DataMoverKubeVirt,
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: velerov2alpha1.DataUploadPhaseFailed,
+				},
+			},
+			expectedRequeue: false,
+			expectedPhase:   velerov2alpha1.DataUploadPhaseFailed,
+			expectError:     false,
+		},
+		{
+			name: "canceled phase is terminal - no action",
+			dataUpload: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover: DataMoverKubeVirt,
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: velerov2alpha1.DataUploadPhaseCanceled,
+				},
+			},
+			expectedRequeue: false,
+			expectedPhase:   velerov2alpha1.DataUploadPhaseCanceled,
+			expectError:     false,
+		},
+		{
+			name: "canceling phase transitions to canceled",
+			dataUpload: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover: DataMoverKubeVirt,
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: velerov2alpha1.DataUploadPhaseCanceling,
+				},
+			},
+			expectedRequeue: false,
+			expectedPhase:   velerov2alpha1.DataUploadPhaseCanceled,
+			expectError:     false,
+		},
+		{
+			name: "prepared phase transitions to inprogress",
+			dataUpload: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover: DataMoverKubeVirt,
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: velerov2alpha1.DataUploadPhasePrepared,
+				},
+			},
+			expectedRequeue: true,
+			expectedPhase:   velerov2alpha1.DataUploadPhaseInProgress,
+			expectError:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.dataUpload).
+				Build()
+
+			r := &KubeVirtDataUploadReconciler{
+				Client:        fakeClient,
+				Scheme:        scheme,
+				Log:           logr.Discard(),
+				OADPNamespace: "openshift-adp",
+			}
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      tt.dataUpload.Name,
+					Namespace: tt.dataUpload.Namespace,
+				},
+			}
+
+			result, err := r.Reconcile(context.Background(), req)
+
+			if tt.expectError && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if result.Requeue != tt.expectedRequeue {
+				t.Errorf("expected requeue=%v, got requeue=%v", tt.expectedRequeue, result.Requeue)
+			}
+
+			// Verify phase if we expect a transition
+			if tt.expectedPhase != "" && tt.dataUpload.Spec.DataMover == DataMoverKubeVirt {
+				updatedDU := &velerov2alpha1.DataUpload{}
+				err := fakeClient.Get(context.Background(), req.NamespacedName, updatedDU)
+				if err != nil {
+					t.Errorf("failed to get updated DataUpload: %v", err)
+				}
+				if updatedDU.Status.Phase != tt.expectedPhase {
+					t.Errorf("expected phase=%s, got phase=%s", tt.expectedPhase, updatedDU.Status.Phase)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcile_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		OADPNamespace: "openshift-adp",
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "non-existent",
+			Namespace: "openshift-adp",
+		},
+	}
+
+	result, err := r.Reconcile(context.Background(), req)
+
+	if err != nil {
+		t.Errorf("expected no error for not-found, got: %v", err)
+	}
+	if result.Requeue {
+		t.Errorf("expected no requeue for not-found")
+	}
+}
+
+func TestFilterKubeVirtDataMover(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataMover string
+		expected  bool
+	}{
+		{
+			name:      "kubevirt datamover matches",
+			dataMover: DataMoverKubeVirt,
+			expected:  true,
+		},
+		{
+			name:      "velero datamover does not match",
+			dataMover: "velero",
+			expected:  false,
+		},
+		{
+			name:      "empty datamover does not match",
+			dataMover: "",
+			expected:  false,
+		},
+		{
+			name:      "kopia datamover does not match",
+			dataMover: "kopia",
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the filter logic directly - this is what the predicate checks
+			matches := tt.dataMover == DataMoverKubeVirt
+			if matches != tt.expected {
+				t.Errorf("expected match=%v, got match=%v for datamover=%s",
+					tt.expected, matches, tt.dataMover)
+			}
+		})
+	}
+}
+
+func TestUpdatePhase(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name         string
+		initialPhase velerov2alpha1.DataUploadPhase
+		targetPhase  velerov2alpha1.DataUploadPhase
+		message      string
+		expectError  bool
+	}{
+		{
+			name:         "update from new to accepted",
+			initialPhase: velerov2alpha1.DataUploadPhaseNew,
+			targetPhase:  velerov2alpha1.DataUploadPhaseAccepted,
+			message:      "DataUpload accepted by kubevirt datamover",
+			expectError:  false,
+		},
+		{
+			name:         "update from accepted to prepared",
+			initialPhase: velerov2alpha1.DataUploadPhaseAccepted,
+			targetPhase:  velerov2alpha1.DataUploadPhasePrepared,
+			message:      "VMBT/VMB created",
+			expectError:  false,
+		},
+		{
+			name:         "update from prepared to inprogress",
+			initialPhase: velerov2alpha1.DataUploadPhasePrepared,
+			targetPhase:  velerov2alpha1.DataUploadPhaseInProgress,
+			message:      "Datamover pod launched",
+			expectError:  false,
+		},
+		{
+			name:         "update from inprogress to completed",
+			initialPhase: velerov2alpha1.DataUploadPhaseInProgress,
+			targetPhase:  velerov2alpha1.DataUploadPhaseCompleted,
+			message:      "Backup completed successfully",
+			expectError:  false,
+		},
+		{
+			name:         "update from canceling to canceled",
+			initialPhase: velerov2alpha1.DataUploadPhaseCanceling,
+			targetPhase:  velerov2alpha1.DataUploadPhaseCanceled,
+			message:      "DataUpload canceled",
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			du := &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover: DataMoverKubeVirt,
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: tt.initialPhase,
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(du).
+				Build()
+
+			r := &KubeVirtDataUploadReconciler{
+				Client:        fakeClient,
+				Scheme:        scheme,
+				Log:           logr.Discard(),
+				OADPNamespace: "openshift-adp",
+			}
+
+			err := r.updatePhase(context.Background(), du, tt.targetPhase, tt.message)
+
+			if tt.expectError && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Verify the phase was updated
+			updatedDU := &velerov2alpha1.DataUpload{}
+			err = fakeClient.Get(context.Background(), types.NamespacedName{
+				Name:      du.Name,
+				Namespace: du.Namespace,
+			}, updatedDU)
+			if err != nil {
+				t.Errorf("failed to get updated DataUpload: %v", err)
+			}
+			if updatedDU.Status.Phase != tt.targetPhase {
+				t.Errorf("expected phase=%s, got phase=%s", tt.targetPhase, updatedDU.Status.Phase)
+			}
+			if updatedDU.Status.Message != tt.message {
+				t.Errorf("expected message=%s, got message=%s", tt.message, updatedDU.Status.Message)
+			}
+		})
+	}
+}
+
+func TestHandleAccepted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+
+	du := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-du",
+			Namespace: "openshift-adp",
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover: DataMoverKubeVirt,
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseAccepted,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du).
+		Build()
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		OADPNamespace: "openshift-adp",
+	}
+
+	result, err := r.handleAccepted(context.Background(), logr.Discard(), du)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Currently handleAccepted just logs and returns - no requeue
+	if result.Requeue {
+		t.Errorf("expected no requeue from handleAccepted (not yet implemented)")
+	}
+}
+
+func TestHandleInProgress(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+
+	du := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-du",
+			Namespace: "openshift-adp",
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover: DataMoverKubeVirt,
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseInProgress,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du).
+		Build()
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		OADPNamespace: "openshift-adp",
+	}
+
+	result, err := r.handleInProgress(context.Background(), logr.Discard(), du)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Currently handleInProgress just logs and returns - no requeue
+	if result.Requeue {
+		t.Errorf("expected no requeue from handleInProgress (not yet implemented)")
+	}
+}
+
+func TestDefaultMaxConcurrentReconciles(t *testing.T) {
+	if DefaultMaxConcurrentReconciles != 3 {
+		t.Errorf("expected DefaultMaxConcurrentReconciles=3, got %d", DefaultMaxConcurrentReconciles)
+	}
+}
+
+func TestDataMoverKubeVirtConstant(t *testing.T) {
+	if DataMoverKubeVirt != "kubevirt" {
+		t.Errorf("expected DataMoverKubeVirt='kubevirt', got '%s'", DataMoverKubeVirt)
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,16 +34,16 @@ import (
 )
 
 // namespace where the project is deployed in
-const namespace = "kubevirt-datamover-controller-system"
+const namespace = "kubevirt-datamover-system"
 
 // serviceAccountName created for the project
-const serviceAccountName = "kubevirt-datamover-controller-controller-manager"
+const serviceAccountName = "kubevirt-datamover-controller-manager"
 
 // metricsServiceName is the name of the metrics service of the project
-const metricsServiceName = "kubevirt-datamover-controller-controller-manager-metrics-service"
+const metricsServiceName = "kubevirt-datamover-controller-manager-metrics-service"
 
 // metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
-const metricsRoleBindingName = "kubevirt-datamover-controller-metrics-binding"
+const metricsRoleBindingName = "kubevirt-datamover-metrics-binding"
 
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
@@ -176,7 +176,7 @@ var _ = Describe("Manager", Ordered, func() {
 		It("should ensure the metrics endpoint is serving metrics", func() {
 			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
 			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-				"--clusterrole=kubevirt-datamover-controller-metrics-reader",
+				"--clusterrole=kubevirt-datamover-metrics-reader",
 				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
 			)
 			_, err := utils.Run(cmd)


### PR DESCRIPTION
## Summary

Completes Phase 1 of the KubeVirt DataMover Controller implementation:

- **Rename controller to hybrid naming convention**: `dataupload_controller.go` → `kubevirt_dataupload_controller.go`, `DataUploadReconciler` → `KubeVirtDataUploadReconciler`
- **Add phase-based reconciliation logic**: Implements Velero DataUpload lifecycle phases (New → Accepted → Prepared → InProgress → Completed/Failed/Canceled)
- **Add concurrency configuration**: `--max-concurrent-reconciles` CLI flag with default of 3 workers
- **Add `.claude/` to `.gitignore`**: For local AI assistant memory files

## Testing

Deployed to OCP cluster and verified:
- ✅ Controller runs and acquires leader election
- ✅ Watches velero.io/DataUpload resources cluster-wide
- ✅ Correctly filters for `datamover: kubevirt` DataUploads
- ✅ Phase transition logic works (attempted New → Accepted update)
- ✅ 3 concurrent workers running

Note: Race condition with Velero's controller is expected until upstream changes (Issue #2057) are implemented.

## Test plan

- [x] Build and push image to ttl.sh
- [x] Deploy controller to OCP cluster with OADP installed
- [x] Create test DataUpload with `datamover: kubevirt`
- [x] Verify controller logs show reconciliation
- [x] Verify phase transition attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)