### PR TITLE
chore: Add OWNERS file for Prow integration

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,0 +1,38 @@
+name: PR Automation
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  label-and-assign:
+    name: Label and Assign PR
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Add label and assign author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+
+            // Add kubevirt-dm label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['kubevirt-dm']
+            });
+
+            // Assign PR to author
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              assignees: [author]
+            });
+
+            console.log(`Added label 'kubevirt-dm' and assigned PR #${prNumber} to ${author}`);

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,16 @@
+approvers:
+  - kaovilai
+  - mpryc
+  - mrnold
+  - rayfordj
+  - shawn-hurley
+  - shubham-pampattiwar
+  - sseago
+  - weshayutin
+reviewers:
+  - kaovilai
+  - mpryc
+  - mrnold
+  - shubham-pampattiwar
+  - sseago
+  - weshayutin


### PR DESCRIPTION
## Summary
- Add OWNERS file with approvers and reviewers matching oadp-vm-file-restore repository
- Required for Prow CI integration (defines who can `/lgtm` and `/approve` PRs)

## Test plan
- [x] File follows standard OWNERS format
- [x] Team members match oadp-vm-file-restore

🤖 Generated with [Claude Code](https://claude.ai/code)