### PR TITLE
Add shared GetPVCsForVM and SnapshotTypeCSI to pkg/common

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -51,6 +51,13 @@ const (
 	DataMoverKubeVirt = "kubevirt"
 )
 
+// SnapshotType constants for DataUpload
+const (
+	// SnapshotTypeCSI is the snapshot type for CSI-based backups.
+	// The kubevirt datamover uses CSI snapshots as the underlying mechanism.
+	SnapshotTypeCSI = "CSI"
+)
+
 // DataUpload Phase Transitions (for documentation):
 //
 // The kubevirt-datamover-controller handles the following phase transitions:

--- a/pkg/common/validation.go
+++ b/pkg/common/validation.go
@@ -116,3 +116,37 @@ func ValidateVMForBackup(vm *kubevirtcorev1.VirtualMachine) error {
 
 	return nil
 }
+
+// GetVolumesForVm returns a list of PVC names associated with the VirtualMachine.
+// It extracts PVC names from:
+// - PersistentVolumeClaim volume sources
+// - DataVolume volume sources (which create PVCs with the same name)
+// - MemoryDump volume sources
+func GetVolumesForVm(vm *kubevirtcorev1.VirtualMachine) []string {
+	var pvcNames []string
+
+	if vm == nil {
+		return pvcNames
+	}
+
+	if vm.Spec.Template == nil || vm.Spec.Template.Spec.Volumes == nil {
+		return pvcNames
+	}
+
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		// Check for PersistentVolumeClaim source
+		if volume.PersistentVolumeClaim != nil {
+			pvcNames = append(pvcNames, volume.PersistentVolumeClaim.ClaimName)
+		}
+		// Check for DataVolume source (which creates a PVC with the same name)
+		if volume.DataVolume != nil {
+			pvcNames = append(pvcNames, volume.DataVolume.Name)
+		}
+		// Check for memory dump volume
+		if volume.MemoryDump != nil {
+			pvcNames = append(pvcNames, volume.MemoryDump.ClaimName)
+		}
+	}
+
+	return pvcNames
+}

--- a/pkg/common/validation_test.go
+++ b/pkg/common/validation_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	velerov2alpha1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 )
@@ -420,6 +421,284 @@ func TestValidateVMForBackup(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestGetVolumesForVm(t *testing.T) {
+	tests := []struct {
+		name     string
+		vm       *kubevirtcorev1.VirtualMachine
+		expected []string
+	}{
+		{
+			name:     "nil VM",
+			vm:       nil,
+			expected: []string{},
+		},
+		{
+			name: "VM with nil Template",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: nil,
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "VM with nil Volumes",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: nil,
+						},
+					},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "VM with empty Volumes",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{},
+						},
+					},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "VM with PVC volume",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "disk0",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+												ClaimName: "pvc-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"pvc-1"},
+		},
+		{
+			name: "VM with DataVolume",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "disk0",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										DataVolume: &kubevirtcorev1.DataVolumeSource{
+											Name: "dv-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"dv-1"},
+		},
+		{
+			name: "VM with MemoryDump volume",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "memory-dump",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										MemoryDump: &kubevirtcorev1.MemoryDumpVolumeSource{
+											PersistentVolumeClaimVolumeSource: kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+												PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+													ClaimName: "memory-dump-pvc",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"memory-dump-pvc"},
+		},
+		{
+			name: "VM with multiple volumes",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "disk0",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+												ClaimName: "pvc-1",
+											},
+										},
+									},
+								},
+								{
+									Name: "disk1",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										DataVolume: &kubevirtcorev1.DataVolumeSource{
+											Name: "dv-1",
+										},
+									},
+								},
+								{
+									Name: "disk2",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+												ClaimName: "pvc-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"pvc-1", "dv-1", "pvc-2"},
+		},
+		{
+			name: "VM with non-PVC volumes only",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "cloudinit",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										CloudInitNoCloud: &kubevirtcorev1.CloudInitNoCloudSource{
+											UserData: "test",
+										},
+									},
+								},
+								{
+									Name: "containerDisk",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										ContainerDisk: &kubevirtcorev1.ContainerDiskSource{
+											Image: "test-image",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "VM with mixed PVC and non-PVC volumes",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "disk0",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+												ClaimName: "pvc-1",
+											},
+										},
+									},
+								},
+								{
+									Name: "cloudinit",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										CloudInitNoCloud: &kubevirtcorev1.CloudInitNoCloudSource{
+											UserData: "test",
+										},
+									},
+								},
+								{
+									Name: "disk1",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										DataVolume: &kubevirtcorev1.DataVolumeSource{
+											Name: "dv-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"pvc-1", "dv-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetVolumesForVm(tt.vm)
+
+			// Use ElementsMatch to handle nil vs empty slice and ordering differences
+			assert.ElementsMatch(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
Move PVC extraction logic and snapshot type constant to the shared common package so both the controller and kubevirt-datamover-plugin use the same implementation, ensuring consistency when processing VirtualMachine volumes.