### PR TITLE
Update Dockerfile to allow prow build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,38 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore everything by default and re-include only needed files
-**
+# Ignore build artifacts and non-essential files
+bin/
+cover.out
+*.out
 
-# Re-include Go source files (but not *_test.go)
-!**/*.go
+# Ignore test files
 **/*_test.go
 
-# Re-include Go module files
-!go.mod
-!go.sum
+# Ignore IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Ignore git
+.git/
+.github/
+
+# Ignore documentation
+*.md
+LICENSE
+OWNERS
+
+# Ignore config (not needed in container build)
+config/
+.devcontainer/
+hack/
+test/
+
+# Ignore dotfiles
+.gitignore
+.golangci.yml
+.dockerignore
+
+# Ignore Makefile and project metadata
+Makefile
+PROJECT

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the Go source (relies on .dockerignore to filter)
-COPY . .
+# Copy the go source
+COPY cmd/main.go cmd/main.go
+COPY internal/ internal/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has no default value to allow the binary to be built according to the host where the command


### PR DESCRIPTION
Updated Dockerfile, similarly to what oadp-vm-file-restore controller is using.

Reworked .dockerignore.