### PR TITLE
fix: Check both Done and Progressing conditions on VMBackup status

### DIFF
--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -331,33 +331,58 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 	}
 
-	// Simple logic: check the Done condition only
-	for _, cond := range vmb.Status.Conditions {
-		if cond.Type == kubevirtbackupv1alpha1.ConditionDone {
-			if cond.Status == corev1.ConditionTrue {
-				// Success
-				logger.Info("VirtualMachineBackup completed",
-					"vmb", vmb.Name,
-					"type", vmb.Status.Type,
-					"checkpoint", vmb.Status.CheckpointName)
+	return r.evaluateVMBackupStatus(ctx, logger, du, vmb)
+}
 
-				if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhasePrepared,
-					fmt.Sprintf("VMBackup completed (type=%s)", vmb.Status.Type)); err != nil {
-					return ctrl.Result{}, err
-				}
-				return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
-			}
-			// Done: False means explicit failure
-			logger.Error(nil, "VirtualMachineBackup failed", "reason", cond.Reason, "message", cond.Message)
+// evaluateVMBackupStatus checks the Done and Progressing conditions on a VirtualMachineBackup
+// to determine whether the backup succeeded, failed, or is still running.
+// KubeVirt uses both conditions together:
+//
+//	Progressing=True  + Done=False  → backup still running
+//	Progressing=False + Done=True   → backup completed successfully
+//	Progressing=False + Done=False  → backup failed
+func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
+	ctx context.Context, logger logr.Logger,
+	du *velerov2alpha1.DataUpload, vmb *kubevirtbackupv1alpha1.VirtualMachineBackup,
+) (ctrl.Result, error) {
+	var doneCond, progressingCond *kubevirtbackupv1alpha1.Condition
+	for i := range vmb.Status.Conditions {
+		switch vmb.Status.Conditions[i].Type {
+		case kubevirtbackupv1alpha1.ConditionDone:
+			doneCond = &vmb.Status.Conditions[i]
+		case kubevirtbackupv1alpha1.ConditionProgressing:
+			progressingCond = &vmb.Status.Conditions[i]
+		}
+	}
+
+	if doneCond != nil && doneCond.Status == corev1.ConditionTrue {
+		logger.Info("VirtualMachineBackup completed",
+			"vmb", vmb.Name,
+			"type", vmb.Status.Type,
+			"checkpoint", vmb.Status.CheckpointName)
+
+		if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhasePrepared,
+			fmt.Sprintf("VMBackup completed (type=%s)", vmb.Status.Type)); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
+	}
+
+	if doneCond != nil && doneCond.Status == corev1.ConditionFalse {
+		if progressingCond != nil && progressingCond.Status == corev1.ConditionFalse {
+			// Progressing=False + Done=False → actual failure
+			logger.Error(nil, "VirtualMachineBackup failed", "reason", doneCond.Reason, "message", doneCond.Message)
 			if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
-				fmt.Sprintf("VMBackup failed: %s", cond.Message)); err != nil {
+				fmt.Sprintf("VMBackup failed: %s", doneCond.Message)); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
 		}
+		// Done=False but Progressing is True or absent → backup still running
+		logger.Info("VirtualMachineBackup still in progress (Done=False, waiting for completion)", "vmb", vmb.Name)
 	}
 
-	// No Done condition yet - still in progress
+	// No Done condition yet, or backup still running - requeue
 	logger.Info("VirtualMachineBackup in progress, requeuing")
 	return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 }

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -541,8 +541,13 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			expectRequeue: true,
 		},
 		{
-			name: "VMB Done False transitions to Failed",
+			name: "VMB Done False and Progressing False transitions to Failed",
 			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "BackupFailed",
+				},
 				{
 					Type:    kubevirtbackupv1alpha1.ConditionDone,
 					Status:  corev1.ConditionFalse,
@@ -552,6 +557,36 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			},
 			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
 			expectRequeue: false,
+		},
+		{
+			name: "VMB Done False and Progressing True requeues (backup still running)",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionTrue,
+					Reason: "Backup is in progress",
+				},
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionDone,
+					Status: corev1.ConditionFalse,
+					Reason: "Backup is in progress",
+				},
+			},
+			expectedPhase: velerov2alpha1.DataUploadPhaseAccepted, // unchanged - still running
+			expectRequeue: true,
+		},
+		{
+			name: "VMB Done False without Progressing requeues",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:    kubevirtbackupv1alpha1.ConditionDone,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Backup is in progress",
+					Message: "",
+				},
+			},
+			expectedPhase: velerov2alpha1.DataUploadPhaseAccepted, // unchanged - wait for Progressing
+			expectRequeue: true,
 		},
 		{
 			name: "VMB only Progressing True requeues",


### PR DESCRIPTION
## Summary
- Fixes race condition where `DataUpload` was incorrectly marked as `Failed` while the `VirtualMachineBackup` was still in progress
- The `handleAccepted` phase now checks **both** `Done` and `Progressing` conditions instead of only `Done`
- Only marks failure when `Done=False` AND `Progressing=False` (confirmed failure), requeues when backup is still running

## Root Cause
KubeVirt sets `Done=False` with `Progressing=True` while the backup is actively running. The controller was treating any `Done=False` as a terminal failure, causing a race condition where the DataUpload was marked `Failed` even though the VMBackup completed successfully moments later.

| Progressing | Done | Meaning | Controller action |
|---|---|---|---|
| `True` | `False` | Backup still running | Requeue (was: **incorrectly failing**) |
| `False` | `True` | Completed successfully | Mark Prepared |
| `False` | `False` | Actual failure | Mark Failed |

Fixes #16

## Test plan
- [x] Updated existing "VMB Done False" test to include `Progressing=False` (actual failure case)
- [x] Added test: `Done=False` + `Progressing=True` → requeues (the race condition scenario)
- [x] Added test: `Done=False` without `Progressing` → requeues (conservative, wait for signal)
- [x] All 7 VMB status detection tests pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup state detection to distinguish completed, in-progress, and failed virtual machine backups and added clearer logging and retry behavior.
* **Tests**
  * Expanded test coverage with scenarios for in-progress, failed, and awaiting-progressing backup states to validate status transitions and requeue logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->