### PR TITLE
Issue #15: Make sure created CRs have names that are valid (and not too long)

### DIFF
--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -70,6 +70,14 @@ const (
 	vmbtLabelVMName = "kubevirt-datamover.io/vm-name"
 	// AnnotationVMBTName is the annotation key for the generated VMBT name on a DataUpload
 	AnnotationVMBTName = "kubevirt-datamover.io/vmbt-name"
+
+	// k8sGenerateNameRandomLen is the number of random characters K8s appends to GenerateName
+	k8sGenerateNameRandomLen = 5
+
+	// maxVMBNameLen is the max allowed VMB name length. KubeVirt constructs a
+	// hotplug volume name as "<vmb-name>-backup-target-pvc" which must be a
+	// valid DNS label (≤ 63 chars). Reserve 18 chars for that suffix.
+	maxVMBNameLen = 63 - len("-backup-target-pvc") // = 45
 )
 
 // KubeVirtDataUploadReconciler reconciles DataUpload objects where Spec.DataMover is "kubevirt"
@@ -631,7 +639,7 @@ func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logge
 	podToCreate := buildDatamoverPod(podConfig)
 
 	// Use GenerateName instead of a fixed name
-	podToCreate.GenerateName = fmt.Sprintf("%s%s-", common.DatamoverPodNamePrefix, du.Name)
+	podToCreate.GenerateName = safeGenerateNamePrefix(fmt.Sprintf("%s%s-", common.DatamoverPodNamePrefix, du.Name), 63)
 	podToCreate.Name = ""
 
 	// Set owner reference so pod is cleaned up when DataUpload is deleted
@@ -889,7 +897,7 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 	// Create new PVC
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("kubevirt-backup-%s-", du.Name),
+			GenerateName: safeGenerateNamePrefix(fmt.Sprintf("kubevirt-backup-%s-", du.Name), 63),
 			Namespace:    namespace,
 			Labels: map[string]string{
 				common.LabelDataUploadName: du.Name,
@@ -962,7 +970,7 @@ func (r *KubeVirtDataUploadReconciler) prepareVMBackupTracker(ctx context.Contex
 	apiGroup := "kubevirt.io"
 	vmbt := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("vmbt-%s-", vmName),
+			GenerateName: safeGenerateNamePrefix(fmt.Sprintf("vmbt-%s-", vmName), 63),
 			Namespace:    vmNamespace,
 			Labels: map[string]string{
 				common.LabelDataUploadName: du.Name,
@@ -1086,7 +1094,7 @@ func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logge
 	apiGroup := "backup.kubevirt.io"
 	vmb := &kubevirtbackupv1alpha1.VirtualMachineBackup{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("vmb-%s-", du.Name),
+			GenerateName: safeGenerateNamePrefix(fmt.Sprintf("vmb-%s-", du.Name), maxVMBNameLen),
 			Namespace:    namespace,
 			Labels: map[string]string{
 				common.LabelDataUploadName: du.Name,
@@ -1158,6 +1166,19 @@ func getVeleroBackupName(du *velerov2alpha1.DataUpload) string {
 		return ""
 	}
 	return du.Labels[common.LabelVeleroBackupName]
+}
+
+// safeGenerateNamePrefix truncates a GenerateName prefix so that the final
+// name (prefix + 5 random chars) does not exceed maxNameLen.
+func safeGenerateNamePrefix(prefix string, maxNameLen int) string {
+	maxPrefix := maxNameLen - k8sGenerateNameRandomLen
+	if maxPrefix < 1 {
+		maxPrefix = 1
+	}
+	if len(prefix) > maxPrefix {
+		prefix = prefix[:maxPrefix]
+	}
+	return prefix
 }
 
 // buildDatamoverPodConfig assembles the configuration for the datamover pod

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -696,7 +696,7 @@ func (r *KubeVirtDataUploadReconciler) handleInProgress(ctx context.Context, log
 
 	case corev1.PodFailed:
 		failureMessage := extractPodFailureMessage(pod)
-		logger.Error(nil, "Datamover pod failed", "pod", podName, "message", failureMessage)
+		logger.Error(nil, "Datamover pod failed", "pod", pod.Name, "message", failureMessage)
 
 		// Skip cleanup on failure to preserve resources for debugging.
 		// Resources (pod, rebound PVC/PV) can be manually cleaned up after investigation.
@@ -707,11 +707,11 @@ func (r *KubeVirtDataUploadReconciler) handleInProgress(ctx context.Context, log
 		return ctrl.Result{}, nil
 
 	case corev1.PodPending, corev1.PodRunning:
-		logger.V(1).Info("Datamover pod still running", "pod", podName, "phase", pod.Status.Phase)
+		logger.V(1).Info("Datamover pod still running", "pod", pod.Name, "phase", pod.Status.Phase)
 		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 
 	default:
-		logger.Info("Datamover pod in unknown phase", "pod", podName, "phase", pod.Status.Phase)
+		logger.Info("Datamover pod in unknown phase", "pod", pod.Name, "phase", pod.Status.Phase)
 		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 	}
 }
@@ -1104,12 +1104,11 @@ func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logge
 		},
 	}
 
-	if forceFullBackup {
-		logger.Info("Creating VirtualMachineBackup with ForceFullBackup=true", "vmb", vmbName)
-	}
-
 	if err := r.Create(ctx, vmb); err != nil {
 		return nil, false, fmt.Errorf("failed to create VirtualMachineBackup: %w", err)
+	}
+	if forceFullBackup {
+		logger.Info("Creating VirtualMachineBackup with ForceFullBackup=true", "vmb", vmb.Name)
 	}
 
 	logger.Info("Created VirtualMachineBackup", "generateName", vmb.GenerateName, "namespace", namespace, "tracker", vmbt.Name)

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -65,6 +65,11 @@ const (
 
 	// defaultCredentialKey is the default key in BSL credential secrets
 	defaultCredentialKey = "cloud"
+
+	// vmbtLabelVMName is the label key for the VM name on a VirtualMachineBackupTracker
+	vmbtLabelVMName = "kubevirt-datamover.io/vm-name"
+	// AnnotationVMBTName is the annotation key for the generated VMBT name on a DataUpload
+	AnnotationVMBTName = "kubevirt-datamover.io/vmbt-name"
 )
 
 // KubeVirtDataUploadReconciler reconciles DataUpload objects where Spec.DataMover is "kubevirt"
@@ -257,22 +262,12 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 	// Check if VMB already exists. If it does, the VMBT is already in the right
 	// state (set before VMB creation) and we can skip straight to monitoring.
 	// This avoids deleting/recreating the VMBT while an active VMB references it.
-	vmbName := fmt.Sprintf("%s%s", common.VMBackupNamePrefix, du.Name)
-	existingVMB := &kubevirtbackupv1alpha1.VirtualMachineBackup{}
-	vmbExists := false
-	if err := r.Get(ctx, types.NamespacedName{Name: vmbName, Namespace: vmRef.Namespace}, existingVMB); err == nil {
-		vmbExists = true
-	} else if !errors.IsNotFound(err) {
+	vmb, err := r.findVMBForDataUpload(ctx, du, vmRef.Namespace)
+	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to check for existing VMB: %w", err)
 	}
 
-	var vmb *kubevirtbackupv1alpha1.VirtualMachineBackup
-	if vmbExists {
-		// VMB already exists — skip VMBT preparation and backup mode resolution.
-		// The VMBT was set up before this VMB was created and should not be disturbed.
-		vmb = existingVMB
-		logger.V(1).Info("VirtualMachineBackup already exists, skipping VMBT preparation", "vmb", vmb.Name)
-	} else {
+	if vmb == nil {
 		// Step 2: Prepare VirtualMachineBackupTracker (recreate from S3 state)
 		vmbt, err := r.prepareVMBackupTracker(ctx, logger, du, vmRef.Name, vmRef.Namespace)
 		if err != nil {
@@ -280,6 +275,15 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 			return ctrl.Result{}, err
 		}
 		logger.Info("VirtualMachineBackupTracker ready", "vmbt", vmbt.Name)
+
+		// Store generated VMBT name in annotation for later stages
+		if du.Annotations == nil {
+			du.Annotations = make(map[string]string)
+		}
+		du.Annotations[AnnotationVMBTName] = vmbt.Name
+		if err := r.Update(ctx, du); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to annotate DataUpload with VMBT name: %w", err)
+		}
 
 		// Step 3: Determine backup mode (full vs incremental).
 		forceFullBackup, checkpointLookup := r.resolveBackupMode(ctx, logger, du, vmRef)
@@ -319,10 +323,12 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 		}
 
 		if created {
-			logger.Info("Created VirtualMachineBackup", "vmb", vmb.Name)
+			logger.Info("Created VirtualMachineBackup", "generateName", vmb.GenerateName, "namespace", vmRef.Namespace)
 			// Requeue to check status
 			return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 		}
+	} else {
+		logger.V(1).Info("VirtualMachineBackup already exists, skipping VMBT preparation", "vmb", vmb.Name)
 	}
 
 	// Step 5: Check VMB status
@@ -505,19 +511,17 @@ func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logge
 	podNamespace := r.getPodNamespace(du)
 
 	// Check if datamover pod already exists (idempotency)
-	podName := getDatamoverPodName(du)
-	existingPod := &corev1.Pod{}
-	err = r.Get(ctx, types.NamespacedName{Name: podName, Namespace: podNamespace}, existingPod)
-	if err == nil {
+	pod, err := r.findPodForDataUpload(ctx, du, podNamespace)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check for existing datamover pod: %w", err)
+	}
+	if pod != nil {
 		// Pod exists, transition to InProgress and monitor
-		logger.Info("Datamover pod already exists, transitioning to InProgress", "pod", podName)
+		logger.Info("Datamover pod already exists, transitioning to InProgress", "pod", pod.Name)
 		if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseInProgress, "Datamover pod running"); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
-	}
-	if !errors.IsNotFound(err) {
-		return ctrl.Result{}, fmt.Errorf("failed to check for existing datamover pod: %w", err)
 	}
 
 	// Validate BSL and VMB exist BEFORE rebinding PV
@@ -534,10 +538,13 @@ func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logge
 	}
 
 	// Get VMB to extract checkpoint info
-	vmb, err := r.getVMBackup(ctx, du, vmRef.Namespace)
+	vmb, err := r.findVMBForDataUpload(ctx, du, vmRef.Namespace)
 	if err != nil {
-		logger.Error(err, "Failed to get VirtualMachineBackup")
-		if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed, fmt.Sprintf("Failed to get VMB: %v", err)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get VirtualMachineBackup: %w", err)
+	}
+	if vmb == nil {
+		logger.Error(nil, "VirtualMachineBackup not found for DataUpload")
+		if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed, "VirtualMachineBackup not found"); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -592,8 +599,22 @@ func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logge
 		checkpointName = *vmb.Status.CheckpointName
 	}
 
+	// Get VMBT name from annotation
+	vmbtName := ""
+	if du.Annotations != nil {
+		vmbtName = du.Annotations[AnnotationVMBTName]
+	}
+	if vmbtName == "" {
+		err := fmt.Errorf("VMBT name annotation %s not found on DataUpload", AnnotationVMBTName)
+		logger.Error(err, "Failed to get VMBT name")
+		if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed, err.Error()); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
 	// Build datamover pod config - now using OADP namespace and rebound PVC
-	podConfig, err := r.buildDatamoverPodConfig(du, bsl, vmb, vmRef, backupType, checkpointName)
+	podConfig, err := r.buildDatamoverPodConfig(du, bsl, vmb, vmRef, backupType, checkpointName, vmbtName)
 	if err != nil {
 		logger.Error(err, "Failed to build datamover pod config")
 		if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed, fmt.Sprintf("Failed to build pod config: %v", err)); err != nil {
@@ -607,23 +628,27 @@ func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logge
 	podConfig.SourcePVCName = reboundPVCName
 
 	// Create the datamover pod
-	pod := buildDatamoverPod(podConfig)
+	podToCreate := buildDatamoverPod(podConfig)
+
+	// Use GenerateName instead of a fixed name
+	podToCreate.GenerateName = fmt.Sprintf("%s%s-", common.DatamoverPodNamePrefix, du.Name)
+	podToCreate.Name = ""
 
 	// Set owner reference so pod is cleaned up when DataUpload is deleted
 	// This works now because pod is in the same namespace as DataUpload
-	if err := controllerutil.SetOwnerReference(du, pod, r.Scheme); err != nil {
+	if err := controllerutil.SetOwnerReference(du, podToCreate, r.Scheme); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set owner reference on pod: %w", err)
 	}
 
-	if err := r.Create(ctx, pod); err != nil {
+	if err := r.Create(ctx, podToCreate); err != nil {
 		if errors.IsAlreadyExists(err) {
 			// Race condition - pod was created between check and create
-			logger.Info("Datamover pod already exists (race)", "pod", podName)
+			logger.Info("Datamover pod already exists (race)", "generateName", podToCreate.GenerateName)
 		} else {
 			return ctrl.Result{}, fmt.Errorf("failed to create datamover pod: %w", err)
 		}
 	} else {
-		logger.Info("Created datamover pod", "pod", podName, "namespace", podNamespace)
+		logger.Info("Created datamover pod", "generateName", podToCreate.GenerateName, "namespace", podNamespace)
 	}
 
 	// Transition to InProgress
@@ -643,25 +668,23 @@ func (r *KubeVirtDataUploadReconciler) handleInProgress(ctx context.Context, log
 	podNamespace := r.getPodNamespace(du)
 
 	// Get the datamover pod
-	podName := getDatamoverPodName(du)
-	pod := &corev1.Pod{}
-	err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: podNamespace}, pod)
+	pod, err := r.findPodForDataUpload(ctx, du, podNamespace)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// Pod not found - this is unexpected in InProgress phase
-			logger.Error(err, "Datamover pod not found", "pod", podName, "namespace", podNamespace)
-			if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed, "Datamover pod not found"); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, nil
-		}
 		return ctrl.Result{}, fmt.Errorf("failed to get datamover pod: %w", err)
+	}
+	if pod == nil {
+		// Pod not found - this is unexpected in InProgress phase
+		logger.Error(err, "Datamover pod not found", "dataUpload", du.Name, "namespace", podNamespace)
+		if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed, "Datamover pod not found"); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
 	}
 
 	// Check pod status
 	switch pod.Status.Phase {
 	case corev1.PodSucceeded:
-		logger.Info("Datamover pod completed successfully", "pod", podName)
+		logger.Info("Datamover pod completed successfully", "pod", pod.Name)
 
 		// Cleanup resources
 		r.cleanupDatamoverResources(ctx, logger, du, podNamespace)
@@ -696,13 +719,17 @@ func (r *KubeVirtDataUploadReconciler) handleInProgress(ctx context.Context, log
 // cleanupDatamoverResources cleans up resources created during the datamover process
 func (r *KubeVirtDataUploadReconciler) cleanupDatamoverResources(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, podNamespace string) {
 	// Delete the datamover pod
-	podName := getDatamoverPodName(du)
-	pod := &corev1.Pod{}
-	if err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: podNamespace}, pod); err == nil {
-		if err := r.Delete(ctx, pod); err != nil && !errors.IsNotFound(err) {
-			logger.Error(err, "Failed to delete datamover pod", "pod", podName)
-		} else {
-			logger.Info("Deleted datamover pod", "pod", podName)
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList, client.InNamespace(podNamespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		logger.Error(err, "Failed to list datamover pods for cleanup")
+	} else {
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			if err := r.Delete(ctx, pod); err != nil && !errors.IsNotFound(err) {
+				logger.Error(err, "Failed to delete datamover pod", "pod", pod.Name)
+			} else {
+				logger.Info("Deleted datamover pod", "pod", pod.Name)
+			}
 		}
 	}
 
@@ -718,23 +745,31 @@ func (r *KubeVirtDataUploadReconciler) cleanupDatamoverResources(ctx context.Con
 // cleanupVMBackupResources deletes VMB and VMBT CRs in the VM namespace.
 // Used during cancellation when the datamover pod won't run its own cleanup.
 func (r *KubeVirtDataUploadReconciler) cleanupVMBackupResources(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, vmName, vmNamespace string) {
-	vmbName := fmt.Sprintf("vmb-%s", du.Name)
-	vmb := &kubevirtbackupv1alpha1.VirtualMachineBackup{}
-	if err := r.Get(ctx, types.NamespacedName{Name: vmbName, Namespace: vmNamespace}, vmb); err == nil {
-		if err := r.Delete(ctx, vmb); err != nil && !errors.IsNotFound(err) {
-			logger.Error(err, "Failed to delete VMB", "vmb", vmbName)
-		} else {
-			logger.Info("Deleted VMB", "vmb", vmbName, "namespace", vmNamespace)
+	vmbList := &kubevirtbackupv1alpha1.VirtualMachineBackupList{}
+	if err := r.List(ctx, vmbList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		logger.Error(err, "Failed to list VMBs for cleanup")
+	} else {
+		for i := range vmbList.Items {
+			vmb := &vmbList.Items[i]
+			if err := r.Delete(ctx, vmb); err != nil && !errors.IsNotFound(err) {
+				logger.Error(err, "Failed to delete VMB", "vmb", vmb.Name)
+			} else {
+				logger.Info("Deleted VMB", "vmb", vmb.Name, "namespace", vmNamespace)
+			}
 		}
 	}
 
-	vmbtName := fmt.Sprintf("vmbt-%s", vmName)
-	vmbt := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{}
-	if err := r.Get(ctx, types.NamespacedName{Name: vmbtName, Namespace: vmNamespace}, vmbt); err == nil {
-		if err := r.Delete(ctx, vmbt); err != nil && !errors.IsNotFound(err) {
-			logger.Error(err, "Failed to delete VMBT", "vmbt", vmbtName)
-		} else {
-			logger.Info("Deleted VMBT", "vmbt", vmbtName, "namespace", vmNamespace)
+	vmbtList := &kubevirtbackupv1alpha1.VirtualMachineBackupTrackerList{}
+	if err := r.List(ctx, vmbtList, client.InNamespace(vmNamespace), client.MatchingLabels{vmbtLabelVMName: vmName}); err != nil {
+		logger.Error(err, "Failed to list VMBTs for cleanup")
+	} else {
+		for i := range vmbtList.Items {
+			vmbt := &vmbtList.Items[i]
+			if err := r.Delete(ctx, vmbt); err != nil && !errors.IsNotFound(err) {
+				logger.Error(err, "Failed to delete VMBT", "vmbt", vmbt.Name)
+			} else {
+				logger.Info("Deleted VMBT", "vmbt", vmbt.Name, "namespace", vmNamespace)
+			}
 		}
 	}
 }
@@ -839,25 +874,23 @@ func (r *KubeVirtDataUploadReconciler) filterKubeVirtDataMover() predicate.Predi
 // while DataUpload is in OADP namespace (cross-namespace owner refs not allowed).
 // The PVC will be cleaned up during PV rebinding or explicit cleanup.
 func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, namespace string) (*corev1.PersistentVolumeClaim, error) {
-	pvcName := fmt.Sprintf("kubevirt-backup-%s", du.Name)
-
-	// Check if PVC already exists
-	existingPVC := &corev1.PersistentVolumeClaim{}
-	err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: namespace}, existingPVC)
-	if err == nil {
-		logger.V(1).Info("Temporary PVC already exists", "pvc", pvcName)
-		return existingPVC, nil
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := r.List(ctx, pvcList, client.InNamespace(namespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		return nil, fmt.Errorf("failed to list temporary PVCs: %w", err)
 	}
-
-	if !errors.IsNotFound(err) {
-		return nil, fmt.Errorf("failed to check for existing PVC: %w", err)
+	if len(pvcList.Items) > 1 {
+		return nil, fmt.Errorf("found multiple temporary PVCs for DataUpload %s", du.Name)
+	}
+	if len(pvcList.Items) == 1 {
+		logger.V(1).Info("Temporary PVC already exists", "pvc", pvcList.Items[0].Name)
+		return &pvcList.Items[0], nil
 	}
 
 	// Create new PVC
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      pvcName,
-			Namespace: namespace,
+			GenerateName: fmt.Sprintf("kubevirt-backup-%s-", du.Name),
+			Namespace:    namespace,
 			Labels: map[string]string{
 				common.LabelDataUploadName: du.Name,
 				common.LabelDataUploadUID:  string(du.UID),
@@ -879,7 +912,7 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 		return nil, fmt.Errorf("failed to create temporary PVC: %w", err)
 	}
 
-	logger.Info("Created temporary PVC", "pvc", pvcName, "namespace", namespace)
+	logger.Info("Created temporary PVC", "generateName", pvc.GenerateName, "namespace", namespace)
 	return pvc, nil
 }
 
@@ -887,7 +920,19 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 // restoring the LatestCheckpoint from the archived VMBT in S3 if available.
 // Any existing VMBT is deleted first to avoid conflicts (S3 is the source of truth).
 func (r *KubeVirtDataUploadReconciler) prepareVMBackupTracker(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, vmName, vmNamespace string) (*kubevirtbackupv1alpha1.VirtualMachineBackupTracker, error) {
-	vmbtName := fmt.Sprintf("vmbt-%s", vmName)
+	// Delete any existing VMBT for this VM before creating a new one.
+	// This ensures we always start from the state restored from S3.
+	existingVMBTList := &kubevirtbackupv1alpha1.VirtualMachineBackupTrackerList{}
+	if err := r.List(ctx, existingVMBTList, client.InNamespace(vmNamespace), client.MatchingLabels{vmbtLabelVMName: vmName}); err != nil {
+		return nil, fmt.Errorf("failed to list existing VMBTs: %w", err)
+	}
+	for i := range existingVMBTList.Items {
+		vmbtToDelete := &existingVMBTList.Items[i]
+		logger.Info("Deleting existing VMBT before recreation", "vmbt", vmbtToDelete.Name)
+		if err := r.Delete(ctx, vmbtToDelete); err != nil && !errors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to delete existing VMBT %s: %w", vmbtToDelete.Name, err)
+		}
+	}
 
 	// Try to fetch the archived VMBT from S3 to restore LatestCheckpoint.
 	// This is non-fatal: if BSL is unreachable or no VMBT exists yet (first backup),
@@ -913,26 +958,15 @@ func (r *KubeVirtDataUploadReconciler) prepareVMBackupTracker(ctx context.Contex
 		}
 	}
 
-	// Delete existing VMBT unconditionally (we're recreating from S3 state)
-	existingVMBT := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{}
-	err := r.Get(ctx, types.NamespacedName{Name: vmbtName, Namespace: vmNamespace}, existingVMBT)
-	if err == nil {
-		logger.Info("Deleting existing VMBT before recreation", "vmbt", vmbtName)
-		if err := r.Delete(ctx, existingVMBT); err != nil && !errors.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to delete existing VMBT %s: %w", vmbtName, err)
-		}
-	} else if !errors.IsNotFound(err) {
-		return nil, fmt.Errorf("failed to check for existing VMBT: %w", err)
-	}
-
 	// Create new VMBT
 	apiGroup := "kubevirt.io"
 	vmbt := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmbtName,
-			Namespace: vmNamespace,
+			GenerateName: fmt.Sprintf("vmbt-%s-", vmName),
+			Namespace:    vmNamespace,
 			Labels: map[string]string{
 				common.LabelDataUploadName: du.Name,
+				vmbtLabelVMName:            vmName,
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
@@ -948,7 +982,7 @@ func (r *KubeVirtDataUploadReconciler) prepareVMBackupTracker(ctx context.Contex
 		return nil, fmt.Errorf("failed to create VirtualMachineBackupTracker: %w", err)
 	}
 
-	logger.Info("Created VirtualMachineBackupTracker", "vmbt", vmbtName, "namespace", vmNamespace)
+	logger.Info("Created VirtualMachineBackupTracker", "generateName", vmbt.GenerateName, "namespace", vmNamespace)
 
 	// If we have an archived VMBT with LatestCheckpoint, set it on the new VMBT's status.
 	// K8s ignores Status during creation, so we must use Status().Update() separately.
@@ -960,7 +994,7 @@ func (r *KubeVirtDataUploadReconciler) prepareVMBackupTracker(ctx context.Contex
 			return nil, fmt.Errorf("failed to update VMBT status with LatestCheckpoint: %w", err)
 		}
 		logger.Info("Set VMBT LatestCheckpoint from S3 archive",
-			"vmbt", vmbtName,
+			"vmbt", vmbt.Name,
 			"latestCheckpoint", archivedVMBT.Status.LatestCheckpoint.Name)
 	}
 
@@ -1038,27 +1072,22 @@ func (r *KubeVirtDataUploadReconciler) lookupLatestVMBTFromBSL(ctx context.Conte
 // while DataUpload is in OADP namespace (cross-namespace owner refs not allowed).
 // VMB and VMBT are archived to S3 and deleted by the datamover pod after upload.
 func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, vmbt *kubevirtbackupv1alpha1.VirtualMachineBackupTracker, pvcName, namespace string, forceFullBackup bool) (*kubevirtbackupv1alpha1.VirtualMachineBackup, bool, error) {
-	// Use DataUpload name for VMB to ensure 1:1 mapping
-	vmbName := fmt.Sprintf("vmb-%s", du.Name)
-
-	// Check if VMB already exists
-	existingVMB := &kubevirtbackupv1alpha1.VirtualMachineBackup{}
-	err := r.Get(ctx, types.NamespacedName{Name: vmbName, Namespace: namespace}, existingVMB)
-	if err == nil {
-		logger.V(1).Info("VirtualMachineBackup already exists", "vmb", vmbName)
-		return existingVMB, false, nil
-	}
-
-	if !errors.IsNotFound(err) {
+	// Find existing VMB for this DataUpload
+	existingVMB, err := r.findVMBForDataUpload(ctx, du, namespace)
+	if err != nil {
 		return nil, false, fmt.Errorf("failed to check for existing VMB: %w", err)
+	}
+	if existingVMB != nil {
+		logger.V(1).Info("VirtualMachineBackup already exists", "vmb", existingVMB.Name)
+		return existingVMB, false, nil
 	}
 
 	// Create new VMB referencing the VMBT (enables incremental backups)
 	apiGroup := "backup.kubevirt.io"
 	vmb := &kubevirtbackupv1alpha1.VirtualMachineBackup{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmbName,
-			Namespace: namespace,
+			GenerateName: fmt.Sprintf("vmb-%s-", du.Name),
+			Namespace:    namespace,
 			Labels: map[string]string{
 				common.LabelDataUploadName: du.Name,
 				common.LabelDataUploadUID:  string(du.UID),
@@ -1083,13 +1112,8 @@ func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logge
 		return nil, false, fmt.Errorf("failed to create VirtualMachineBackup: %w", err)
 	}
 
-	logger.Info("Created VirtualMachineBackup", "vmb", vmbName, "namespace", namespace, "tracker", vmbt.Name)
+	logger.Info("Created VirtualMachineBackup", "generateName", vmb.GenerateName, "namespace", namespace, "tracker", vmbt.Name)
 	return vmb, true, nil
-}
-
-// getDatamoverPodName returns the name for the datamover pod
-func getDatamoverPodName(du *velerov2alpha1.DataUpload) string {
-	return fmt.Sprintf("%s%s", common.DatamoverPodNamePrefix, du.Name)
 }
 
 // getBackupStorageLocation fetches the BSL referenced by the DataUpload
@@ -1114,16 +1138,19 @@ func (r *KubeVirtDataUploadReconciler) getBackupStorageLocation(ctx context.Cont
 	return bsl, nil
 }
 
-// getVMBackup fetches the VirtualMachineBackup for this DataUpload
-func (r *KubeVirtDataUploadReconciler) getVMBackup(ctx context.Context, du *velerov2alpha1.DataUpload, namespace string) (*kubevirtbackupv1alpha1.VirtualMachineBackup, error) {
-	vmbName := fmt.Sprintf("%s%s", common.VMBackupNamePrefix, du.Name)
-
-	vmb := &kubevirtbackupv1alpha1.VirtualMachineBackup{}
-	if err := r.Get(ctx, types.NamespacedName{Name: vmbName, Namespace: namespace}, vmb); err != nil {
-		return nil, fmt.Errorf("failed to get VirtualMachineBackup %s/%s: %w", namespace, vmbName, err)
+// findVMBForDataUpload finds the unique VirtualMachineBackup associated with a DataUpload.
+func (r *KubeVirtDataUploadReconciler) findVMBForDataUpload(ctx context.Context, du *velerov2alpha1.DataUpload, namespace string) (*kubevirtbackupv1alpha1.VirtualMachineBackup, error) {
+	vmbList := &kubevirtbackupv1alpha1.VirtualMachineBackupList{}
+	if err := r.List(ctx, vmbList, client.InNamespace(namespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		return nil, err
 	}
-
-	return vmb, nil
+	if len(vmbList.Items) == 0 {
+		return nil, nil
+	}
+	if len(vmbList.Items) > 1 {
+		return nil, fmt.Errorf("found multiple VirtualMachineBackups for DataUpload %s", du.Name)
+	}
+	return &vmbList.Items[0], nil
 }
 
 // getVeleroBackupName extracts the Velero backup name from DataUpload labels
@@ -1142,6 +1169,7 @@ func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 	vmRef *common.VMReference,
 	backupType string,
 	checkpointName string,
+	vmbtName string,
 ) (*DatamoverPodConfig, error) {
 	cfg, err := extractBSLConfig(bsl)
 	if err != nil {
@@ -1167,7 +1195,7 @@ func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 	}
 
 	return &DatamoverPodConfig{
-		Name:                 getDatamoverPodName(du),
+		Name:                 du.Name, // Used as a prefix for GenerateName
 		Namespace:            vmRef.Namespace,
 		Image:                image,
 		ImagePullPolicy:      pullPolicy,
@@ -1185,7 +1213,7 @@ func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 		DataUploadName:       du.Name,
 		DataUploadUID:        string(du.UID),
 		VMBName:              vmb.Name,
-		VMBTName:             fmt.Sprintf("vmbt-%s", vmRef.Name),
+		VMBTName:             vmbtName,
 		SourcePVCName:        pvcName,
 		Labels:               make(map[string]string),
 	}, nil
@@ -1373,4 +1401,19 @@ func (r *KubeVirtDataUploadReconciler) getCredentialsFromBSL(
 	}
 
 	return credData, nil
+}
+
+// findPodForDataUpload finds the unique datamover pod associated with a DataUpload.
+func (r *KubeVirtDataUploadReconciler) findPodForDataUpload(ctx context.Context, du *velerov2alpha1.DataUpload, namespace string) (*corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		return nil, err
+	}
+	if len(podList.Items) == 0 {
+		return nil, nil
+	}
+	if len(podList.Items) > 1 {
+		return nil, fmt.Errorf("found multiple datamover pods for DataUpload %s", du.Name)
+	}
+	return &podList.Items[0], nil
 }

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -900,8 +900,10 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 			GenerateName: safeGenerateNamePrefix(fmt.Sprintf("kubevirt-backup-%s-", du.Name), 63),
 			Namespace:    namespace,
 			Labels: map[string]string{
-				common.LabelDataUploadName: du.Name,
-				common.LabelDataUploadUID:  string(du.UID),
+				common.LabelDataUploadUID: string(du.UID),
+			},
+			Annotations: map[string]string{
+				common.AnnotationDataUploadName: du.Name,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -973,8 +975,10 @@ func (r *KubeVirtDataUploadReconciler) prepareVMBackupTracker(ctx context.Contex
 			GenerateName: safeGenerateNamePrefix(fmt.Sprintf("vmbt-%s-", vmName), 63),
 			Namespace:    vmNamespace,
 			Labels: map[string]string{
-				common.LabelDataUploadName: du.Name,
-				vmbtLabelVMName:            vmName,
+				vmbtLabelVMName: vmName,
+			},
+			Annotations: map[string]string{
+				common.AnnotationDataUploadName: du.Name,
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
@@ -1097,8 +1101,10 @@ func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logge
 			GenerateName: safeGenerateNamePrefix(fmt.Sprintf("vmb-%s-", du.Name), maxVMBNameLen),
 			Namespace:    namespace,
 			Labels: map[string]string{
-				common.LabelDataUploadName: du.Name,
-				common.LabelDataUploadUID:  string(du.UID),
+				common.LabelDataUploadUID: string(du.UID),
+			},
+			Annotations: map[string]string{
+				common.AnnotationDataUploadName: du.Name,
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -682,7 +682,7 @@ func (r *KubeVirtDataUploadReconciler) handleInProgress(ctx context.Context, log
 	}
 	if pod == nil {
 		// Pod not found - this is unexpected in InProgress phase
-		logger.Error(err, "Datamover pod not found", "dataUpload", du.Name, "namespace", podNamespace)
+		logger.Error(nil, "Datamover pod not found", "dataUpload", du.Name, "namespace", podNamespace)
 		if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed, "Datamover pod not found"); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -1171,10 +1171,7 @@ func getVeleroBackupName(du *velerov2alpha1.DataUpload) string {
 // safeGenerateNamePrefix truncates a GenerateName prefix so that the final
 // name (prefix + 5 random chars) does not exceed maxNameLen.
 func safeGenerateNamePrefix(prefix string, maxNameLen int) string {
-	maxPrefix := maxNameLen - k8sGenerateNameRandomLen
-	if maxPrefix < 1 {
-		maxPrefix = 1
-	}
+	maxPrefix := max(maxNameLen-k8sGenerateNameRandomLen, 1)
 	if len(prefix) > maxPrefix {
 		prefix = prefix[:maxPrefix]
 	}

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -708,8 +708,10 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 					Name:      "vmb-" + duName,
 					Namespace: vmNamespace,
 					Labels: map[string]string{
-						common.LabelDataUploadName: duName,
-						common.LabelDataUploadUID:  string(du.UID),
+						common.LabelDataUploadUID: string(du.UID),
+					},
+					Annotations: map[string]string{
+						common.AnnotationDataUploadName: duName,
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -2230,8 +2232,10 @@ func TestHandleAccepted_WithBSLCheckpointLookup(t *testing.T) {
 			Name:      "vmb-" + duName,
 			Namespace: vmNamespace,
 			Labels: map[string]string{
-				common.LabelDataUploadName: duName,
-				common.LabelDataUploadUID:  "test-uid",
+				common.LabelDataUploadUID: "test-uid",
+			},
+			Annotations: map[string]string{
+				common.AnnotationDataUploadName: duName,
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{
@@ -2363,8 +2367,10 @@ func TestHandleAccepted_NoBSLConfigured(t *testing.T) {
 			Name:      "vmb-" + duName,
 			Namespace: vmNamespace,
 			Labels: map[string]string{
-				common.LabelDataUploadName: duName,
-				common.LabelDataUploadUID:  string(du.UID),
+				common.LabelDataUploadUID: string(du.UID),
+			},
+			Annotations: map[string]string{
+				common.AnnotationDataUploadName: duName,
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{
@@ -2859,8 +2865,10 @@ func TestHandleAccepted_HappyPath_IncrementalBackup(t *testing.T) {
 			Name:      "vmb-" + duName,
 			Namespace: vmNamespace,
 			Labels: map[string]string{
-				common.LabelDataUploadName: duName,
-				common.LabelDataUploadUID:  "test-uid",
+				common.LabelDataUploadUID: "test-uid",
+			},
+			Annotations: map[string]string{
+				common.AnnotationDataUploadName: duName,
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{
@@ -4862,9 +4870,9 @@ func TestPrepareVMBackupTracker_DeletesExisting(t *testing.T) {
 	if vmbt.Labels["stale-label"] == "old-value" {
 		t.Error("expected old VMBT to be deleted and new one created, but old labels persist")
 	}
-	if vmbt.Labels[common.LabelDataUploadName] != duName {
-		t.Errorf("expected new VMBT to have DataUpload label %q, got %q",
-			duName, vmbt.Labels[common.LabelDataUploadName])
+	if vmbt.Annotations[common.AnnotationDataUploadName] != duName {
+		t.Errorf("expected new VMBT to have DataUpload annotation %q, got %q",
+			duName, vmbt.Annotations[common.AnnotationDataUploadName])
 	}
 	if vmbt.Labels[vmbtLabelVMName] != vmName {
 		t.Errorf("expected new VMBT to have label %s, got %q",

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -38,12 +39,8 @@ import (
 	kubevirtbackupv1alpha1 "kubevirt.io/api/backup/v1alpha1"
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-)
-
-const (
-	vmbtLabelVMName    = "kubevirt-datamover.io/vm-name"
-	AnnotationVMBTName = "kubevirt-datamover.io/vmbt-name"
 )
 
 func TestReconcile(t *testing.T) {
@@ -774,18 +771,6 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 
 			if updatedDU.Status.Phase != tt.expectedPhase {
 				t.Errorf("expected phase=%s, got phase=%s", tt.expectedPhase, updatedDU.Status.Phase)
-			}
-
-			if !tt.expectError && tt.expectedPhase == velerov2alpha1.DataUploadPhaseInProgress {
-				// Check if a pod was created
-				podList := &corev1.PodList{}
-				err := fakeClient.List(context.Background(), podList, client.InNamespace("openshift-adp"), client.MatchingLabels{common.LabelDataUploadUID: string(tt.du.UID)})
-				if err != nil {
-					t.Fatalf("failed to list pods: %v", err)
-				}
-				if len(podList.Items) != 1 {
-					t.Errorf("expected 1 pod to be created, but found %d", len(podList.Items))
-				}
 			}
 		})
 	}
@@ -2342,6 +2327,10 @@ func TestHandleAccepted_NoBSLConfigured(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubevirt-backup-" + duName,
 			Namespace: vmNamespace,
+			Labels: map[string]string{
+				common.LabelDataUploadName: du.Name,
+				common.LabelDataUploadUID:  string(du.UID),
+			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -2375,6 +2364,7 @@ func TestHandleAccepted_NoBSLConfigured(t *testing.T) {
 			Namespace: vmNamespace,
 			Labels: map[string]string{
 				common.LabelDataUploadName: duName,
+				common.LabelDataUploadUID:  string(du.UID),
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -5072,13 +5072,13 @@ func TestSafeGenerateNamePrefix(t *testing.T) {
 			name:       "long prefix is truncated",
 			prefix:     "a-very-long-prefix-that-will-be-truncated-and-should-not-exceed-the-limit-",
 			maxNameLen: 63,
-			expected:   "a-very-long-prefix-that-will-be-truncated-and-should-no", // 58 chars
+			expected:   "a-very-long-prefix-that-will-be-truncated-and-should-not-e", // 58 chars
 		},
 		{
 			name:       "long prefix for VMB is truncated",
 			prefix:     "vmb-a-very-long-dataupload-name-that-exceeds-the-limit-for-kubevirt-hotplug-",
-			maxNameLen: maxVMBNameLen, // 45
-			expected:   "vmb-a-very-long-dataupload-name-that-e", // 40 chars = 45 - 5
+			maxNameLen: maxVMBNameLen,                              // 45
+			expected:   "vmb-a-very-long-dataupload-name-that-exc", // 40 chars = 45 - 5
 		},
 		{
 			name:       "edge case: maxNameLen < random part",
@@ -5107,10 +5107,7 @@ func TestSafeGenerateNamePrefix(t *testing.T) {
 				t.Errorf("safeGenerateNamePrefix() = %q, want %q", result, tt.expected)
 			}
 			// Sanity check length
-			maxPrefixLen := tt.maxNameLen - k8sGenerateNameRandomLen
-			if maxPrefixLen < 1 {
-				maxPrefixLen = 1
-			}
+			maxPrefixLen := max(tt.maxNameLen-k8sGenerateNameRandomLen, 1)
 			if len(result) > maxPrefixLen {
 				t.Errorf("result length %d exceeds max prefix length %d", len(result), maxPrefixLen)
 			}

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -41,6 +41,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const (
+	vmbtLabelVMName    = "kubevirt-datamover.io/vm-name"
+	AnnotationVMBTName = "kubevirt-datamover.io/vmbt-name"
+)
+
 func TestReconcile(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = velerov2alpha1.AddToScheme(scheme)
@@ -480,6 +485,7 @@ func TestHandleAccepted(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-du",
 			Namespace: "openshift-adp",
+			UID:       types.UID("test-uid-in-progress"),
 		},
 		Spec: velerov2alpha1.DataUploadSpec{
 			DataMover: common.DataMoverKubeVirt,
@@ -655,6 +661,9 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kubevirt-backup-" + duName,
 					Namespace: vmNamespace,
+					Labels: map[string]string{
+						common.LabelDataUploadUID: string(du.UID),
+					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "velero.io/v2alpha1",
@@ -682,6 +691,9 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "vmbt-" + vmName,
 					Namespace: vmNamespace,
+					Labels: map[string]string{
+						vmbtLabelVMName: vmName,
+					},
 				},
 				Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
 					Source: corev1.TypedLocalObjectReference{
@@ -763,6 +775,18 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			if updatedDU.Status.Phase != tt.expectedPhase {
 				t.Errorf("expected phase=%s, got phase=%s", tt.expectedPhase, updatedDU.Status.Phase)
 			}
+
+			if !tt.expectError && tt.expectedPhase == velerov2alpha1.DataUploadPhaseInProgress {
+				// Check if a pod was created
+				podList := &corev1.PodList{}
+				err := fakeClient.List(context.Background(), podList, client.InNamespace("openshift-adp"), client.MatchingLabels{common.LabelDataUploadUID: string(tt.du.UID)})
+				if err != nil {
+					t.Fatalf("failed to list pods: %v", err)
+				}
+				if len(podList.Items) != 1 {
+					t.Errorf("expected 1 pod to be created, but found %d", len(podList.Items))
+				}
+			}
 		})
 	}
 }
@@ -795,6 +819,9 @@ func TestHandleInProgress(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.DatamoverPodNamePrefix + du.Name,
 			Namespace: "openshift-adp",
+			Labels: map[string]string{
+				common.LabelDataUploadUID: string(du.UID),
+			},
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
@@ -1088,6 +1115,7 @@ func TestHandleInProgress_PodSucceeded(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-du",
 			Namespace: "openshift-adp",
+			UID:       types.UID("test-uid-succeeded"),
 			Annotations: map[string]string{
 				common.AnnotationVMName:      "test-vm",
 				common.AnnotationVMNamespace: "test-ns",
@@ -1106,6 +1134,9 @@ func TestHandleInProgress_PodSucceeded(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.DatamoverPodNamePrefix + du.Name,
 			Namespace: "openshift-adp",
+			Labels: map[string]string{
+				common.LabelDataUploadUID: string(du.UID),
+			},
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodSucceeded,
@@ -1156,6 +1187,7 @@ func TestHandleInProgress_PodFailed(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-du",
 			Namespace: "openshift-adp",
+			UID:       types.UID("test-uid-failed"),
 			Annotations: map[string]string{
 				common.AnnotationVMName:      "test-vm",
 				common.AnnotationVMNamespace: "test-ns",
@@ -1174,6 +1206,9 @@ func TestHandleInProgress_PodFailed(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.DatamoverPodNamePrefix + du.Name,
 			Namespace: "openshift-adp",
+			Labels: map[string]string{
+				common.LabelDataUploadUID: string(du.UID),
+			},
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodFailed,
@@ -1234,6 +1269,7 @@ func TestHandleInProgress_PodNotFound(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-du",
 			Namespace: "openshift-adp",
+			UID:       types.UID("test-uid-notfound"),
 			Annotations: map[string]string{
 				common.AnnotationVMName:      "test-vm",
 				common.AnnotationVMNamespace: "test-ns",
@@ -1304,6 +1340,9 @@ func TestCleanupDatamoverResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.DatamoverPodNamePrefix + du.Name,
 			Namespace: "openshift-adp",
+			Labels: map[string]string{
+				common.LabelDataUploadUID: string(du.UID),
+			},
 		},
 	}
 
@@ -1355,21 +1394,6 @@ func TestCleanupDatamoverResources(t *testing.T) {
 	}, deletedPVC)
 	if err == nil {
 		t.Error("expected rebound PVC to be deleted")
-	}
-}
-
-func TestGetDatamoverPodName(t *testing.T) {
-	du := &velerov2alpha1.DataUpload{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-dataupload",
-		},
-	}
-
-	expected := common.DatamoverPodNamePrefix + "my-dataupload"
-	result := getDatamoverPodName(du)
-
-	if result != expected {
-		t.Errorf("getDatamoverPodName() = %q, want %q", result, expected)
 	}
 }
 
@@ -1433,6 +1457,7 @@ func TestBuildDatamoverPodConfig(t *testing.T) {
 		vmRef          *common.VMReference
 		backupType     string
 		checkpointName string
+		vmbtName       string
 		datamoverImage string
 		expectError    bool
 		errorContains  string
@@ -1483,11 +1508,12 @@ func TestBuildDatamoverPodConfig(t *testing.T) {
 			vmRef:          &common.VMReference{Name: "my-vm", Namespace: "vm-ns"},
 			backupType:     "full",
 			checkpointName: "checkpoint-001",
+			vmbtName:       "vmbt-my-vm-xyz",
 			datamoverImage: "quay.io/test/datamover:v1",
 			expectError:    false,
 			validate: func(t *testing.T, config *DatamoverPodConfig) {
-				if config.Name != common.DatamoverPodNamePrefix+"test-du" {
-					t.Errorf("Name = %q, want %q", config.Name, common.DatamoverPodNamePrefix+"test-du")
+				if config.Name != "test-du" {
+					t.Errorf("Name = %q, want %q", config.Name, "test-du")
 				}
 				if config.Namespace != "vm-ns" {
 					t.Errorf("Namespace = %q, want %q", config.Namespace, "vm-ns")
@@ -1512,6 +1538,9 @@ func TestBuildDatamoverPodConfig(t *testing.T) {
 				}
 				if config.CheckpointName != "checkpoint-001" {
 					t.Errorf("CheckpointName = %q, want %q", config.CheckpointName, "checkpoint-001")
+				}
+				if config.VMBTName != "vmbt-my-vm-xyz" {
+					t.Errorf("VMBTName = %q, want %q", config.VMBTName, "vmbt-my-vm-xyz")
 				}
 			},
 		},
@@ -1543,6 +1572,7 @@ func TestBuildDatamoverPodConfig(t *testing.T) {
 			vmRef:          &common.VMReference{Name: "vm", Namespace: "ns"},
 			backupType:     "full",
 			checkpointName: "cp",
+			vmbtName:       "vmbt-vm-123",
 			datamoverImage: "image:v1",
 			expectError:    false,
 			validate: func(t *testing.T, config *DatamoverPodConfig) {
@@ -1645,6 +1675,7 @@ func TestBuildDatamoverPodConfig(t *testing.T) {
 				tt.vmRef,
 				tt.backupType,
 				tt.checkpointName,
+				tt.vmbtName,
 			)
 
 			if tt.expectError {
@@ -1775,81 +1806,6 @@ func TestGetBackupStorageLocation(t *testing.T) {
 	}
 }
 
-func TestGetVMBackup(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = velerov2alpha1.AddToScheme(scheme)
-	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
-
-	tests := []struct {
-		name          string
-		du            *velerov2alpha1.DataUpload
-		vmb           *kubevirtbackupv1alpha1.VirtualMachineBackup
-		namespace     string
-		expectError   bool
-		errorContains string
-	}{
-		{
-			name: "VMB found",
-			du: &velerov2alpha1.DataUpload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-du",
-				},
-			},
-			vmb: &kubevirtbackupv1alpha1.VirtualMachineBackup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vmb-test-du",
-					Namespace: "vm-ns",
-				},
-			},
-			namespace:   "vm-ns",
-			expectError: false,
-		},
-		{
-			name: "VMB not found",
-			du: &velerov2alpha1.DataUpload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-du",
-				},
-			},
-			vmb:           nil,
-			namespace:     "vm-ns",
-			expectError:   true,
-			errorContains: "failed to get VirtualMachineBackup",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			builder := fake.NewClientBuilder().WithScheme(scheme)
-			if tt.vmb != nil {
-				builder = builder.WithObjects(tt.vmb)
-			}
-			fakeClient := builder.Build()
-
-			r := &KubeVirtDataUploadReconciler{
-				Client: fakeClient,
-			}
-
-			vmb, err := r.getVMBackup(context.Background(), tt.du, tt.namespace)
-
-			if tt.expectError {
-				if err == nil {
-					t.Error("expected error but got none")
-				} else if tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
-					t.Errorf("error %q should contain %q", err.Error(), tt.errorContains)
-				}
-			} else {
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-				if vmb == nil {
-					t.Error("expected VMB but got nil")
-				}
-			}
-		})
-	}
-}
-
 func TestHandlePrepared(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = velerov2alpha1.AddToScheme(scheme)
@@ -1877,6 +1833,7 @@ func TestHandlePrepared(t *testing.T) {
 					Annotations: map[string]string{
 						common.AnnotationVMName:      "test-vm",
 						common.AnnotationVMNamespace: "vm-ns",
+						AnnotationVMBTName:           "vmbt-test-vm-abc",
 					},
 					Labels: map[string]string{
 						common.LabelVeleroBackupName: "velero-backup",
@@ -1918,6 +1875,9 @@ func TestHandlePrepared(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "vmb-test-du",
 						Namespace: "vm-ns",
+						Labels: map[string]string{
+							common.LabelDataUploadUID: "du-uid-123",
+						},
 					},
 					Status: &kubevirtbackupv1alpha1.VirtualMachineBackupStatus{
 						Type:           kubevirtbackupv1alpha1.Full,
@@ -3136,13 +3096,14 @@ func TestHandleAccepted_StaleCheckpointForcesFullBackup(t *testing.T) {
 	}
 
 	// Verify VMB was created with ForceFullBackup=true
-	var createdVMB kubevirtbackupv1alpha1.VirtualMachineBackup
-	if err := fakeClient.Get(context.Background(), types.NamespacedName{
-		Name:      "vmb-" + duName,
-		Namespace: vmNamespace,
-	}, &createdVMB); err != nil {
-		t.Fatalf("failed to get created VMB: %v", err)
+	vmbList := &kubevirtbackupv1alpha1.VirtualMachineBackupList{}
+	if err := fakeClient.List(context.Background(), vmbList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		t.Fatalf("failed to list created VMBs: %v", err)
 	}
+	if len(vmbList.Items) != 1 {
+		t.Fatalf("expected 1 VMB to be created, but found %d", len(vmbList.Items))
+	}
+	createdVMB := vmbList.Items[0]
 
 	if !createdVMB.Spec.ForceFullBackup {
 		t.Error("expected VMB.Spec.ForceFullBackup to be true when BSL finds no valid chain")
@@ -4136,13 +4097,14 @@ func TestHandleAccepted_ForceFullBackupAnnotation(t *testing.T) {
 	}
 
 	// Verify VMB was created with ForceFullBackup=true
-	var createdVMB kubevirtbackupv1alpha1.VirtualMachineBackup
-	if err := fakeClient.Get(context.Background(), types.NamespacedName{
-		Name:      "vmb-" + duName,
-		Namespace: vmNamespace,
-	}, &createdVMB); err != nil {
-		t.Fatalf("failed to get created VMB: %v", err)
+	vmbList := &kubevirtbackupv1alpha1.VirtualMachineBackupList{}
+	if err := fakeClient.List(context.Background(), vmbList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		t.Fatalf("failed to list created VMBs: %v", err)
 	}
+	if len(vmbList.Items) != 1 {
+		t.Fatalf("expected 1 VMB to be created, but found %d", len(vmbList.Items))
+	}
+	createdVMB := vmbList.Items[0]
 
 	if !createdVMB.Spec.ForceFullBackup {
 		t.Error("expected VMB.Spec.ForceFullBackup to be true")
@@ -4234,13 +4196,14 @@ func TestHandleAccepted_ForceFullBackupWithNoExistingCheckpoint(t *testing.T) {
 	}
 
 	// Verify VMB was created with ForceFullBackup=true
-	var createdVMB kubevirtbackupv1alpha1.VirtualMachineBackup
-	if err := fakeClient.Get(context.Background(), types.NamespacedName{
-		Name:      "vmb-" + duName,
-		Namespace: vmNamespace,
-	}, &createdVMB); err != nil {
-		t.Fatalf("failed to get created VMB: %v", err)
+	vmbList := &kubevirtbackupv1alpha1.VirtualMachineBackupList{}
+	if err := fakeClient.List(context.Background(), vmbList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		t.Fatalf("failed to list created VMBs: %v", err)
 	}
+	if len(vmbList.Items) != 1 {
+		t.Fatalf("expected 1 VMB to be created, but found %d", len(vmbList.Items))
+	}
+	createdVMB := vmbList.Items[0]
 
 	if !createdVMB.Spec.ForceFullBackup {
 		t.Error("expected VMB.Spec.ForceFullBackup to be true")
@@ -4326,13 +4289,14 @@ func TestHandleAccepted_NoForceFullBackupByDefault(t *testing.T) {
 	}
 
 	// Verify VMB was created with ForceFullBackup=false
-	var createdVMB kubevirtbackupv1alpha1.VirtualMachineBackup
-	if err := fakeClient.Get(context.Background(), types.NamespacedName{
-		Name:      "vmb-" + duName,
-		Namespace: vmNamespace,
-	}, &createdVMB); err != nil {
-		t.Fatalf("failed to get created VMB: %v", err)
+	vmbList := &kubevirtbackupv1alpha1.VirtualMachineBackupList{}
+	if err := fakeClient.List(context.Background(), vmbList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		t.Fatalf("failed to list created VMBs: %v", err)
 	}
+	if len(vmbList.Items) != 1 {
+		t.Fatalf("expected 1 VMB to be created, but found %d", len(vmbList.Items))
+	}
+	createdVMB := vmbList.Items[0]
 
 	if createdVMB.Spec.ForceFullBackup {
 		t.Error("expected VMB.Spec.ForceFullBackup to be false when annotation is not set")
@@ -4470,13 +4434,14 @@ func TestHandleAccepted_StaleCheckpointSetsForceFullOnVMB(t *testing.T) {
 	}
 
 	// Verify VMB was created with ForceFullBackup=true
-	var createdVMB kubevirtbackupv1alpha1.VirtualMachineBackup
-	if err := fakeClient.Get(context.Background(), types.NamespacedName{
-		Name:      "vmb-" + duName,
-		Namespace: vmNamespace,
-	}, &createdVMB); err != nil {
-		t.Fatalf("failed to get created VMB: %v", err)
+	vmbList := &kubevirtbackupv1alpha1.VirtualMachineBackupList{}
+	if err := fakeClient.List(context.Background(), vmbList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		t.Fatalf("failed to list created VMBs: %v", err)
 	}
+	if len(vmbList.Items) != 1 {
+		t.Fatalf("expected 1 VMB to be created, but found %d", len(vmbList.Items))
+	}
+	createdVMB := vmbList.Items[0]
 
 	if !createdVMB.Spec.ForceFullBackup {
 		t.Error("expected VMB.Spec.ForceFullBackup to be true when BSL finds stale checkpoint chain")
@@ -4696,11 +4661,14 @@ func TestPrepareVMBackupTracker_FirstBackup(t *testing.T) {
 	if vmbt == nil {
 		t.Fatal("expected VMBT to be created")
 	}
-	if vmbt.Name != "vmbt-"+vmName {
-		t.Errorf("VMBT name = %q, want %q", vmbt.Name, "vmbt-"+vmName)
+	if !strings.HasPrefix(vmbt.Name, "vmbt-"+vmName) {
+		t.Errorf("VMBT name %q does not have expected prefix", vmbt.Name)
 	}
 	if vmbt.Namespace != vmNamespace {
 		t.Errorf("VMBT namespace = %q, want %q", vmbt.Namespace, vmNamespace)
+	}
+	if vmbt.Labels[vmbtLabelVMName] != vmName {
+		t.Errorf("VMBT is missing label %s", vmbtLabelVMName)
 	}
 	// First backup: no LatestCheckpoint
 	if vmbt.Status != nil && vmbt.Status.LatestCheckpoint != nil {
@@ -4867,10 +4835,11 @@ func TestPrepareVMBackupTracker_DeletesExisting(t *testing.T) {
 	// Pre-create an existing VMBT with stale label
 	existingVMBT := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vmbt-" + vmName,
+			Name:      "vmbt-" + vmName + "-old",
 			Namespace: vmNamespace,
 			Labels: map[string]string{
-				"stale-label": "old-value",
+				"stale-label":   "old-value",
+				vmbtLabelVMName: vmName,
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
@@ -4906,6 +4875,10 @@ func TestPrepareVMBackupTracker_DeletesExisting(t *testing.T) {
 	if vmbt.Labels[common.LabelDataUploadName] != duName {
 		t.Errorf("expected new VMBT to have DataUpload label %q, got %q",
 			duName, vmbt.Labels[common.LabelDataUploadName])
+	}
+	if vmbt.Labels[vmbtLabelVMName] != vmName {
+		t.Errorf("expected new VMBT to have label %s, got %q",
+			vmbtLabelVMName, vmbt.Labels[vmbtLabelVMName])
 	}
 }
 

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -5048,3 +5048,72 @@ func TestLookupLatestVMBTFromBSL(t *testing.T) {
 		})
 	}
 }
+
+func TestSafeGenerateNamePrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		prefix     string
+		maxNameLen int
+		expected   string
+	}{
+		{
+			name:       "short prefix is unchanged",
+			prefix:     "short-prefix-",
+			maxNameLen: 63,
+			expected:   "short-prefix-",
+		},
+		{
+			name:       "prefix exactly at limit is unchanged",
+			prefix:     strings.Repeat("a", 58), // 58 = 63 - 5
+			maxNameLen: 63,
+			expected:   strings.Repeat("a", 58),
+		},
+		{
+			name:       "long prefix is truncated",
+			prefix:     "a-very-long-prefix-that-will-be-truncated-and-should-not-exceed-the-limit-",
+			maxNameLen: 63,
+			expected:   "a-very-long-prefix-that-will-be-truncated-and-should-no", // 58 chars
+		},
+		{
+			name:       "long prefix for VMB is truncated",
+			prefix:     "vmb-a-very-long-dataupload-name-that-exceeds-the-limit-for-kubevirt-hotplug-",
+			maxNameLen: maxVMBNameLen, // 45
+			expected:   "vmb-a-very-long-dataupload-name-that-e", // 40 chars = 45 - 5
+		},
+		{
+			name:       "edge case: maxNameLen < random part",
+			prefix:     "short-",
+			maxNameLen: 4,
+			expected:   "s", // maxPrefix becomes 1
+		},
+		{
+			name:       "edge case: maxNameLen == random part",
+			prefix:     "short-",
+			maxNameLen: 5,
+			expected:   "s", // maxPrefix becomes 1
+		},
+		{
+			name:       "edge case: maxNameLen == random part + 1",
+			prefix:     "short-",
+			maxNameLen: 6,
+			expected:   "s", // maxPrefix is 1, so prefix is truncated to 1
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := safeGenerateNamePrefix(tt.prefix, tt.maxNameLen)
+			if result != tt.expected {
+				t.Errorf("safeGenerateNamePrefix() = %q, want %q", result, tt.expected)
+			}
+			// Sanity check length
+			maxPrefixLen := tt.maxNameLen - k8sGenerateNameRandomLen
+			if maxPrefixLen < 1 {
+				maxPrefixLen = 1
+			}
+			if len(result) > maxPrefixLen {
+				t.Errorf("result length %d exceeds max prefix length %d", len(result), maxPrefixLen)
+			}
+		})
+	}
+}

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -43,12 +43,16 @@ const (
 	// The VMBT checkpoint is cleared and the VMB is created with
 	// ForceFullBackup=true. The new checkpoint replaces the old one in BSL.
 	AnnotationForceFullBackup = "kubevirt-datamover.io/force-full-backup"
+
+	// AnnotationDataUploadName is the annotation key for the DataUpload name.
+	// Used on VMB, VMBT, and PVC resources to track ownership.
+	AnnotationDataUploadName = "velero.io/dataupload-name"
 )
 
 // Label keys for resources created by the controller
 const (
 	// LabelDataUploadName is the label key for the DataUpload name.
-	// Used on VMB, VMBT, and PVC resources to track ownership.
+	// Used on datamover pods to track ownership.
 	LabelDataUploadName = "velero.io/dataupload-name"
 
 	// LabelDataUploadUID is the label key for the DataUpload UID.


### PR DESCRIPTION
Use GenerateName instead of Name for created resources. Look up by label instead of using Get calls.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced naming conflicts and races by switching to generated resource names and safer list-based lookups; cleanup now reliably removes related resources in bulk with per-resource logging.

* **Improvements**
  * More idempotent lifecycle handling across upload phases; generated-name prefixes and persisted name annotations improve cross-stage tracking and clearer logs.
  * Temporary volume handling improved to avoid duplicates.

* **Tests**
  * Expanded coverage for naming, labeling and idempotency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->