### PR TITLE
feat: Add label-safe naming utilities and detect deleted VMBTs

### DIFF
--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -66,8 +66,6 @@ const (
 	// defaultCredentialKey is the default key in BSL credential secrets
 	defaultCredentialKey = "cloud"
 
-	// vmbtLabelVMName is the label key for the VM name on a VirtualMachineBackupTracker
-	vmbtLabelVMName = "kubevirt-datamover.io/vm-name"
 	// AnnotationVMBTName is the annotation key for the generated VMBT name on a DataUpload
 	AnnotationVMBTName = "kubevirt-datamover.io/vmbt-name"
 
@@ -221,6 +219,8 @@ func (r *KubeVirtDataUploadReconciler) handleNew(ctx context.Context, logger log
 
 // handleAccepted processes DataUploads in Accepted phase
 // Creates VMBT/VMB and transitions to Prepared when ready
+//
+//nolint:gocyclo // Phase handler with necessary validation steps
 func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload) (ctrl.Result, error) {
 	logger.Info("Handling Accepted phase DataUpload")
 
@@ -273,6 +273,17 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 	vmb, err := r.findVMBForDataUpload(ctx, du, vmRef.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to check for existing VMB: %w", err)
+	}
+
+	if vmb == nil && du.Annotations != nil && du.Annotations[AnnotationVMBTName] != "" {
+		// The VMBT annotation is set but the VMB isn't visible yet in the cached client.
+		// This happens when a rapid re-reconcile (triggered by the annotation update) runs
+		// before the informer cache has the VMB. Requeue to let the cache catch up.
+		// Without this guard, prepareVMBackupTracker would delete the VMBT that the
+		// (not-yet-visible) VMB references, leaving the VMB permanently stuck.
+		logger.Info("VMBT already prepared but VMB not yet visible in cache, requeuing",
+			"vmbtName", du.Annotations[AnnotationVMBTName])
+		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 	}
 
 	if vmb == nil {
@@ -335,12 +346,29 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 			// Requeue to check status
 			return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 		}
-	} else {
+	} else if vmb != nil {
 		logger.V(1).Info("VirtualMachineBackup already exists, skipping VMBT preparation", "vmb", vmb.Name)
 	}
 
 	// Step 5: Check VMB status
 	if vmb.Status == nil {
+		// Before blindly requeuing, check if the VMB's BackupTracker still exists.
+		// If the VMBT was deleted (by a concurrent DataUpload), KubeVirt will never
+		// set status on this VMB, so we'd requeue forever.
+		vmbtName := vmb.Spec.Source.Name
+		vmbt := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{}
+		if err := r.Get(ctx, types.NamespacedName{Name: vmbtName, Namespace: vmb.Namespace}, vmbt); err != nil {
+			if errors.IsNotFound(err) {
+				logger.Error(nil, "VirtualMachineBackup's BackupTracker was deleted before processing started",
+					"vmb", vmb.Name, "vmbt", vmbtName)
+				if updateErr := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
+					fmt.Sprintf("VMBackup stuck: BackupTracker %s no longer exists", vmbtName)); updateErr != nil {
+					return ctrl.Result{}, updateErr
+				}
+				return ctrl.Result{}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("failed to check BackupTracker %s existence: %w", vmbtName, err)
+		}
 		logger.Info("VirtualMachineBackup status not yet available, requeuing")
 		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 	}
@@ -348,24 +376,27 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 	return r.evaluateVMBackupStatus(ctx, logger, du, vmb)
 }
 
-// evaluateVMBackupStatus checks the Done and Progressing conditions on a VirtualMachineBackup
-// to determine whether the backup succeeded, failed, or is still running.
-// KubeVirt uses both conditions together:
+// evaluateVMBackupStatus checks conditions on a VirtualMachineBackup to determine
+// whether the backup succeeded, failed, or is still running.
+// KubeVirt condition combinations:
 //
-//	Progressing=True  + Done=False  → backup still running
-//	Progressing=False + Done=True   → backup completed successfully
-//	Progressing=False + Done=False  → backup failed
+//	Progressing=True  + Done=False       → backup still running
+//	Progressing=False + Done=True        → backup completed successfully
+//	Progressing=False + Done=False       → backup failed
+//	Initializing=True + Progressing=False + Done=absent → stuck (e.g. VMBT deleted)
 func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 	ctx context.Context, logger logr.Logger,
 	du *velerov2alpha1.DataUpload, vmb *kubevirtbackupv1alpha1.VirtualMachineBackup,
 ) (ctrl.Result, error) {
-	var doneCond, progressingCond *kubevirtbackupv1alpha1.Condition
+	var doneCond, progressingCond, initializingCond *kubevirtbackupv1alpha1.Condition
 	for i := range vmb.Status.Conditions {
 		switch vmb.Status.Conditions[i].Type {
 		case kubevirtbackupv1alpha1.ConditionDone:
 			doneCond = &vmb.Status.Conditions[i]
 		case kubevirtbackupv1alpha1.ConditionProgressing:
 			progressingCond = &vmb.Status.Conditions[i]
+		case kubevirtbackupv1alpha1.ConditionInitializing:
+			initializingCond = &vmb.Status.Conditions[i]
 		}
 	}
 
@@ -394,6 +425,33 @@ func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 		}
 		// Done=False but Progressing is True or absent → backup still running
 		logger.Info("VirtualMachineBackup still in progress (Done=False, waiting for completion)", "vmb", vmb.Name)
+	}
+
+	// Detect stuck initialization: Initializing=True + Progressing=False + no Done condition.
+	// This can be transient (e.g. PVC being hotplugged to VMI) or permanent (VMBT deleted).
+	// To distinguish, we verify the VMB's referenced BackupTracker still exists.
+	// If it's gone, the VMB will never progress — fail immediately.
+	// If it still exists, this is a normal transient state — keep requeuing.
+	if doneCond == nil && initializingCond != nil && initializingCond.Status == corev1.ConditionTrue &&
+		progressingCond != nil && progressingCond.Status == corev1.ConditionFalse {
+		vmbtName := vmb.Spec.Source.Name
+		vmbt := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{}
+		if err := r.Get(ctx, types.NamespacedName{Name: vmbtName, Namespace: vmb.Namespace}, vmbt); err != nil {
+			if errors.IsNotFound(err) {
+				logger.Error(nil, "VirtualMachineBackup's BackupTracker was deleted, failing",
+					"vmb", vmb.Name, "vmbt", vmbtName)
+				if updateErr := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
+					fmt.Sprintf("VMBackup stuck: BackupTracker %s no longer exists", vmbtName)); updateErr != nil {
+					return ctrl.Result{}, updateErr
+				}
+				return ctrl.Result{}, nil
+			}
+			// Transient API error — requeue
+			return ctrl.Result{}, fmt.Errorf("failed to check BackupTracker %s existence: %w", vmbtName, err)
+		}
+		// VMBT exists, initialization is in progress (e.g. PVC being attached) — keep waiting
+		logger.Info("VirtualMachineBackup initializing (VMBT exists, waiting for progress)",
+			"vmb", vmb.Name, "reason", initializingCond.Reason)
 	}
 
 	// No Done condition yet, or backup still running - requeue
@@ -502,6 +560,8 @@ func (r *KubeVirtDataUploadReconciler) validateBSLCheckpoint(ctx context.Context
 
 // handlePrepared processes DataUploads in Prepared phase
 // Rebinds PV to OADP namespace, launches datamover pod, and transitions to InProgress
+//
+//nolint:gocyclo // Phase handler with necessary validation steps
 func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload) (ctrl.Result, error) {
 	logger.Info("Handling Prepared phase DataUpload")
 
@@ -559,7 +619,7 @@ func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logge
 	}
 
 	// Check if PV has already been rebound (idempotency)
-	reboundPVCName := fmt.Sprintf("%s%s", common.ReboundPVCNamePrefix, du.Name)
+	reboundPVCName := common.SafeResourceName(common.ReboundPVCNamePrefix, du.Name)
 	reboundPVC := &corev1.PersistentVolumeClaim{}
 	err = r.Get(ctx, types.NamespacedName{Name: reboundPVCName, Namespace: podNamespace}, reboundPVC)
 	pvAlreadyRebound := err == nil && reboundPVC.Status.Phase == corev1.ClaimBound
@@ -567,14 +627,25 @@ func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logge
 	if !pvAlreadyRebound {
 		// Rebind PV from VM namespace to OADP namespace
 		// This allows the datamover pod to access both the backup data AND credentials
-		sourcePVCName := fmt.Sprintf("%s%s", common.TempPVCNamePrefix, du.Name)
+		//
+		// The temp PVC was created with GenerateName (random suffix), so we read
+		// the actual name from the VMB spec rather than recomputing it.
+		if vmb.Spec.PvcName == nil || *vmb.Spec.PvcName == "" {
+			err := fmt.Errorf("VirtualMachineBackup %s has no PVC name in spec", vmb.Name)
+			logger.Error(err, "Cannot determine source PVC for rebinding")
+			if updateErr := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed, err.Error()); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+			return ctrl.Result{}, nil
+		}
+		sourcePVCName := *vmb.Spec.PvcName
 
 		logger.Info("Rebinding PV from VM namespace to OADP namespace",
 			"sourcePVC", sourcePVCName,
 			"sourceNamespace", vmRef.Namespace,
 			"targetNamespace", podNamespace)
 
-		rebindResult, err := r.rebindPVToNamespace(ctx, logger, sourcePVCName, vmRef.Namespace, podNamespace, du.Name)
+		rebindResult, err := r.rebindPVToNamespace(ctx, logger, sourcePVCName, vmRef.Namespace, podNamespace, du.Name, string(du.UID))
 		if err != nil {
 			// Fail without retry: PV rebind is a multi-step operation (delete PVC, patch PV, create new PVC).
 			// If it fails partway through, automatic retries could leave resources in an inconsistent state.
@@ -742,8 +813,8 @@ func (r *KubeVirtDataUploadReconciler) cleanupDatamoverResources(ctx context.Con
 	}
 
 	// Delete the rebound PVC and PV
-	reboundPVCName := fmt.Sprintf("%s%s", common.ReboundPVCNamePrefix, du.Name)
-	if err := r.cleanupReboundPVCAndPV(ctx, logger, reboundPVCName, podNamespace, du.Name); err != nil {
+	reboundPVCName := common.SafeResourceName(common.ReboundPVCNamePrefix, du.Name)
+	if err := r.cleanupReboundPVCAndPV(ctx, logger, reboundPVCName, podNamespace, string(du.UID)); err != nil {
 		logger.Error(err, "Failed to cleanup rebound PVC and PV", "pvc", reboundPVCName)
 		// Continue - don't block completion on cleanup failures
 	}
@@ -768,7 +839,7 @@ func (r *KubeVirtDataUploadReconciler) cleanupVMBackupResources(ctx context.Cont
 	}
 
 	vmbtList := &kubevirtbackupv1alpha1.VirtualMachineBackupTrackerList{}
-	if err := r.List(ctx, vmbtList, client.InNamespace(vmNamespace), client.MatchingLabels{vmbtLabelVMName: vmName}); err != nil {
+	if err := r.List(ctx, vmbtList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelVMNameHash: common.HashForLabel(vmName)}); err != nil {
 		logger.Error(err, "Failed to list VMBTs for cleanup")
 	} else {
 		for i := range vmbtList.Items {
@@ -933,7 +1004,7 @@ func (r *KubeVirtDataUploadReconciler) prepareVMBackupTracker(ctx context.Contex
 	// Delete any existing VMBT for this VM before creating a new one.
 	// This ensures we always start from the state restored from S3.
 	existingVMBTList := &kubevirtbackupv1alpha1.VirtualMachineBackupTrackerList{}
-	if err := r.List(ctx, existingVMBTList, client.InNamespace(vmNamespace), client.MatchingLabels{vmbtLabelVMName: vmName}); err != nil {
+	if err := r.List(ctx, existingVMBTList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelVMNameHash: common.HashForLabel(vmName)}); err != nil {
 		return nil, fmt.Errorf("failed to list existing VMBTs: %w", err)
 	}
 	for i := range existingVMBTList.Items {
@@ -975,10 +1046,12 @@ func (r *KubeVirtDataUploadReconciler) prepareVMBackupTracker(ctx context.Contex
 			GenerateName: safeGenerateNamePrefix(fmt.Sprintf("vmbt-%s-", vmName), 63),
 			Namespace:    vmNamespace,
 			Labels: map[string]string{
-				vmbtLabelVMName: vmName,
+				common.LabelVMNameHash:    common.HashForLabel(vmName),
+				common.LabelDataUploadUID: string(du.UID),
 			},
 			Annotations: map[string]string{
 				common.AnnotationDataUploadName: du.Name,
+				common.AnnotationVMName:         vmName,
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
@@ -1203,9 +1276,6 @@ func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 		return nil, fmt.Errorf("BSL %s has no credential secret configured", bsl.Name)
 	}
 
-	// Get PVC name
-	pvcName := fmt.Sprintf("%s%s", common.TempPVCNamePrefix, du.Name)
-
 	// Determine datamover image
 	image := r.DatamoverImage
 	if image == "" {
@@ -1237,7 +1307,7 @@ func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 		DataUploadUID:        string(du.UID),
 		VMBName:              vmb.Name,
 		VMBTName:             vmbtName,
-		SourcePVCName:        pvcName,
+		SourcePVCName:        "", // overridden by handlePrepared with the rebound PVC name
 		Labels:               make(map[string]string),
 	}, nil
 }

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -514,6 +514,125 @@ func TestHandleAccepted(t *testing.T) {
 	_ = result // result.RequeueAfter may be > 0 depending on VMB state
 }
 
+// TestHandleAccepted_VMBTAnnotationSetButVMBNotVisible tests the race condition where
+// a rapid re-reconcile runs before the cached client sees the VMB that was just created.
+// The VMBT annotation is already set (from the first reconcile), so the controller must
+// NOT re-enter prepareVMBackupTracker (which would delete the VMBT the VMB references).
+// Instead it should requeue to let the cache catch up.
+func TestHandleAccepted_VMBTAnnotationSetButVMBNotVisible(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = velerov1.AddToScheme(scheme)
+
+	vmName := "test-vm"
+	vmNamespace := "vm-ns"
+	duName := "test-du-race"
+
+	du := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      duName,
+			Namespace: "openshift-adp",
+			UID:       types.UID("du-uid-race"),
+			Annotations: map[string]string{
+				common.AnnotationVMName:      vmName,
+				common.AnnotationVMNamespace: vmNamespace,
+				// VMBT annotation already set by a previous reconcile
+				AnnotationVMBTName: "vmbt-test-vm-prev",
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover:             common.DataMoverKubeVirt,
+			BackupStorageLocation: "default",
+			SourceNamespace:       vmNamespace,
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseAccepted,
+		},
+	}
+
+	bsl := &velerov1.BackupStorageLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "openshift-adp",
+		},
+		Spec: velerov1.BackupStorageLocationSpec{
+			Provider: "aws",
+			StorageType: velerov1.StorageType{
+				ObjectStorage: &velerov1.ObjectStorageLocation{
+					Bucket: "test-bucket",
+					Prefix: "velero",
+				},
+			},
+			Config: map[string]string{"region": "us-east-1"},
+			Credential: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cloud-creds"},
+				Key:                  "cloud",
+			},
+		},
+		Status: velerov1.BackupStorageLocationStatus{
+			Phase: velerov1.BackupStorageLocationPhaseAvailable,
+		},
+	}
+
+	// Temp PVC that was already created by a previous reconcile
+	tempPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-backup-" + duName + "-abc12",
+			Namespace: vmNamespace,
+			Labels: map[string]string{
+				common.LabelDataUploadUID: "du-uid-race",
+			},
+		},
+	}
+
+	// The VMBT that the (not-yet-visible) VMB references — must NOT be deleted
+	vmbt := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vmbt-test-vm-prev",
+			Namespace: vmNamespace,
+			Labels: map[string]string{
+				common.LabelVMNameHash: common.HashForLabel(vmName),
+			},
+		},
+		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{},
+	}
+
+	// No VMB in the fake client — simulates cache lag where VMB isn't visible yet
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du, bsl, tempPVC, vmbt).
+		Build()
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		Log:            logr.Discard(),
+		OADPNamespace:  "openshift-adp",
+		DatamoverImage: "quay.io/test/datamover:v1",
+	}
+
+	result, err := r.handleAccepted(context.Background(), logr.Discard(), du)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should requeue (not fail, not enter VMBT preparation)
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue but got none — controller should wait for cache to catch up")
+	}
+
+	// Verify the VMBT was NOT deleted
+	existingVMBT := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "vmbt-test-vm-prev", Namespace: vmNamespace,
+	}, existingVMBT); err != nil {
+		t.Errorf("VMBT was deleted when it should have been preserved: %v", err)
+	}
+}
+
 func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = velerov2alpha1.AddToScheme(scheme)
@@ -525,6 +644,7 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 		vmbConditions []kubevirtbackupv1alpha1.Condition
 		expectedPhase velerov2alpha1.DataUploadPhase
 		expectRequeue bool
+		skipVMBT      bool // when true, do not create the VMBT (simulates deleted VMBT)
 	}{
 		{
 			name: "VMB Done True transitions to Prepared",
@@ -620,6 +740,41 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			expectRequeue: true,
 		},
 		{
+			name: "VMB stuck initializing (VMBT deleted) transitions to Failed",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionInitializing,
+					Status: corev1.ConditionTrue,
+					Reason: "BackupTracker vmbt-test-vm does not exist",
+				},
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "BackupTracker vmbt-test-vm does not exist",
+				},
+			},
+			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue: false,
+			skipVMBT:      true, // VMBT is gone — this should fail
+		},
+		{
+			name: "VMB initializing with VMBT present requeues (PVC being attached)",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionInitializing,
+					Status: corev1.ConditionTrue,
+					Reason: "backup target PVC is being attached to VMI",
+				},
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "backup target PVC is being attached to VMI",
+				},
+			},
+			expectedPhase: velerov2alpha1.DataUploadPhaseAccepted, // unchanged — transient state
+			expectRequeue: true,
+		},
+		{
 			name:          "VMB no conditions requeues",
 			vmbConditions: []kubevirtbackupv1alpha1.Condition{},
 			expectedPhase: velerov2alpha1.DataUploadPhaseAccepted, // unchanged
@@ -689,7 +844,7 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 					Name:      "vmbt-" + vmName,
 					Namespace: vmNamespace,
 					Labels: map[string]string{
-						vmbtLabelVMName: vmName,
+						common.LabelVMNameHash: common.HashForLabel(vmName),
 					},
 				},
 				Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
@@ -737,9 +892,13 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 				},
 			}
 
+			objects := []client.Object{du, pvc, vmb}
+			if !tt.skipVMBT {
+				objects = append(objects, vmbt)
+			}
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(du, pvc, vmbt, vmb).
+				WithObjects(objects...).
 				Build()
 
 			r := &KubeVirtDataUploadReconciler{
@@ -972,8 +1131,11 @@ func TestAnnotationConstants(t *testing.T) {
 	if common.AnnotationVMNamespace != "kubevirt-datamover.io/vm-namespace" {
 		t.Errorf("expected common.AnnotationVMNamespace='kubevirt-datamover.io/vm-namespace', got '%s'", common.AnnotationVMNamespace)
 	}
-	if common.LabelDataUploadName != "velero.io/dataupload-name" {
-		t.Errorf("expected common.LabelDataUploadName='velero.io/dataupload-name', got '%s'", common.LabelDataUploadName)
+	if common.AnnotationDataUploadName != "velero.io/dataupload-name" {
+		t.Errorf("expected common.AnnotationDataUploadName='velero.io/dataupload-name', got '%s'", common.AnnotationDataUploadName)
+	}
+	if common.LabelVMNameHash != "kubevirt-datamover.io/vm-name-hash" {
+		t.Errorf("expected common.LabelVMNameHash='kubevirt-datamover.io/vm-name-hash', got '%s'", common.LabelVMNameHash)
 	}
 	if common.LabelDataUploadUID != "velero.io/dataupload-uid" {
 		t.Errorf("expected common.LabelDataUploadUID='velero.io/dataupload-uid', got '%s'", common.LabelDataUploadUID)
@@ -1858,6 +2020,7 @@ func TestHandlePrepared(t *testing.T) {
 				}
 
 				checkpointName := "checkpoint-001"
+				tempPVCName := "kubevirt-backup-test-du-abc12"
 				vmb := &kubevirtbackupv1alpha1.VirtualMachineBackup{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "vmb-test-du",
@@ -1865,6 +2028,9 @@ func TestHandlePrepared(t *testing.T) {
 						Labels: map[string]string{
 							common.LabelDataUploadUID: "du-uid-123",
 						},
+					},
+					Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{
+						PvcName: &tempPVCName,
 					},
 					Status: &kubevirtbackupv1alpha1.VirtualMachineBackupStatus{
 						Type:           kubevirtbackupv1alpha1.Full,
@@ -1940,6 +2106,75 @@ func TestHandlePrepared(t *testing.T) {
 				},
 			},
 			setupObjects:  func() []runtime.Object { return nil },
+			expectError:   false,
+			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue: false,
+		},
+		{
+			name:         "VMB without PvcName fails when rebind is needed",
+			datamoverImg: "quay.io/test/datamover:v1",
+			du: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du-no-pvc",
+					Namespace: "openshift-adp",
+					UID:       types.UID("du-uid-nopvc"),
+					Annotations: map[string]string{
+						common.AnnotationVMName:      "test-vm",
+						common.AnnotationVMNamespace: "vm-ns",
+						AnnotationVMBTName:           "vmbt-test-vm-abc",
+					},
+					Labels: map[string]string{
+						common.LabelVeleroBackupName: "velero-backup",
+					},
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover:             common.DataMoverKubeVirt,
+					BackupStorageLocation: "default",
+					SourceNamespace:       "vm-ns",
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: velerov2alpha1.DataUploadPhasePrepared,
+				},
+			},
+			setupObjects: func() []runtime.Object {
+				bsl := &velerov1.BackupStorageLocation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default",
+						Namespace: "openshift-adp",
+					},
+					Spec: velerov1.BackupStorageLocationSpec{
+						Provider: "aws",
+						StorageType: velerov1.StorageType{
+							ObjectStorage: &velerov1.ObjectStorageLocation{
+								Bucket: "test-bucket",
+								Prefix: "velero",
+							},
+						},
+						Config: map[string]string{"region": "us-east-1"},
+						Credential: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "cloud-creds"},
+							Key:                  "cloud",
+						},
+					},
+				}
+
+				// VMB exists but has no PvcName in spec
+				vmb := &kubevirtbackupv1alpha1.VirtualMachineBackup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vmb-test-du-no-pvc",
+						Namespace: "vm-ns",
+						Labels: map[string]string{
+							common.LabelDataUploadUID: "du-uid-nopvc",
+						},
+					},
+					Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{},
+					Status: &kubevirtbackupv1alpha1.VirtualMachineBackupStatus{
+						Type: kubevirtbackupv1alpha1.Full,
+					},
+				}
+				// No rebound PVC exists → rebind path will be taken
+				return []runtime.Object{bsl, vmb}
+			},
 			expectError:   false,
 			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
 			expectRequeue: false,
@@ -2332,8 +2567,7 @@ func TestHandleAccepted_NoBSLConfigured(t *testing.T) {
 			Name:      "kubevirt-backup-" + duName,
 			Namespace: vmNamespace,
 			Labels: map[string]string{
-				common.LabelDataUploadName: du.Name,
-				common.LabelDataUploadUID:  string(du.UID),
+				common.LabelDataUploadUID: string(du.UID),
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -3190,8 +3424,7 @@ func TestHandleAccepted_SkipsBSLValidationWhenAnnotated(t *testing.T) {
 			Name:      "vmb-" + duName,
 			Namespace: vmNamespace,
 			Labels: map[string]string{
-				common.LabelDataUploadName: duName,
-				common.LabelDataUploadUID:  "test-uid",
+				common.LabelDataUploadUID: "test-uid",
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{
@@ -3906,8 +4139,7 @@ func TestHandleAccepted_BSLAnnotationNotSetOnTransientFailure(t *testing.T) {
 			Name:      "vmb-" + duName,
 			Namespace: vmNamespace,
 			Labels: map[string]string{
-				common.LabelDataUploadName: duName,
-				common.LabelDataUploadUID:  "test-uid",
+				common.LabelDataUploadUID: "test-uid",
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{
@@ -4665,8 +4897,11 @@ func TestPrepareVMBackupTracker_FirstBackup(t *testing.T) {
 	if vmbt.Namespace != vmNamespace {
 		t.Errorf("VMBT namespace = %q, want %q", vmbt.Namespace, vmNamespace)
 	}
-	if vmbt.Labels[vmbtLabelVMName] != vmName {
-		t.Errorf("VMBT is missing label %s", vmbtLabelVMName)
+	if vmbt.Labels[common.LabelVMNameHash] != common.HashForLabel(vmName) {
+		t.Errorf("VMBT is missing label %s", common.LabelVMNameHash)
+	}
+	if vmbt.Annotations[common.AnnotationVMName] != vmName {
+		t.Errorf("VMBT annotation %s = %q, want %q", common.AnnotationVMName, vmbt.Annotations[common.AnnotationVMName], vmName)
 	}
 	// First backup: no LatestCheckpoint
 	if vmbt.Status != nil && vmbt.Status.LatestCheckpoint != nil {
@@ -4836,8 +5071,8 @@ func TestPrepareVMBackupTracker_DeletesExisting(t *testing.T) {
 			Name:      "vmbt-" + vmName + "-old",
 			Namespace: vmNamespace,
 			Labels: map[string]string{
-				"stale-label":   "old-value",
-				vmbtLabelVMName: vmName,
+				"stale-label":          "old-value",
+				common.LabelVMNameHash: common.HashForLabel(vmName),
 			},
 		},
 		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
@@ -4874,9 +5109,9 @@ func TestPrepareVMBackupTracker_DeletesExisting(t *testing.T) {
 		t.Errorf("expected new VMBT to have DataUpload annotation %q, got %q",
 			duName, vmbt.Annotations[common.AnnotationDataUploadName])
 	}
-	if vmbt.Labels[vmbtLabelVMName] != vmName {
+	if vmbt.Labels[common.LabelVMNameHash] != common.HashForLabel(vmName) {
 		t.Errorf("expected new VMBT to have label %s, got %q",
-			vmbtLabelVMName, vmbt.Labels[vmbtLabelVMName])
+			common.LabelVMNameHash, vmbt.Labels[common.LabelVMNameHash])
 	}
 }
 

--- a/internal/controller/pod_builder.go
+++ b/internal/controller/pod_builder.go
@@ -67,13 +67,17 @@ type DatamoverPodConfig struct {
 
 // buildDatamoverPod creates a Pod spec for the datamover.
 func buildDatamoverPod(config *DatamoverPodConfig) *corev1.Pod {
-	// Merge default labels with provided labels
+	// Merge default labels with provided labels.
+	// Use UID for labels (always ≤ 63 chars); name goes in annotations.
 	labels := map[string]string{
-		common.LabelDatamoverPod:   "uploader",
-		common.LabelDataUploadName: config.DataUploadName,
-		common.LabelDataUploadUID:  config.DataUploadUID,
+		common.LabelDatamoverPod:  "uploader",
+		common.LabelDataUploadUID: config.DataUploadUID,
 	}
 	maps.Copy(labels, config.Labels)
+
+	annotations := map[string]string{
+		common.AnnotationDataUploadName: config.DataUploadName,
+	}
 
 	// Build environment variables
 	envVars := []corev1.EnvVar{
@@ -105,9 +109,10 @@ func buildDatamoverPod(config *DatamoverPodConfig) *corev1.Pod {
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.Name,
-			Namespace: config.Namespace,
-			Labels:    labels,
+			Name:        config.Name,
+			Namespace:   config.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: corev1.PodSpec{
 			// Use velero service account which has the SCC needed for root access

--- a/internal/controller/pod_builder_test.go
+++ b/internal/controller/pod_builder_test.go
@@ -67,8 +67,11 @@ func TestBuildDatamoverPod(t *testing.T) {
 				if pod.Labels[common.LabelDatamoverPod] != "uploader" {
 					t.Errorf("label %s = %q, want %q", common.LabelDatamoverPod, pod.Labels[common.LabelDatamoverPod], "uploader")
 				}
-				if pod.Labels[common.LabelDataUploadName] != "test-du" {
-					t.Errorf("label %s = %q, want %q", common.LabelDataUploadName, pod.Labels[common.LabelDataUploadName], "test-du")
+				if pod.Labels[common.LabelDataUploadUID] != "uid-12345" {
+					t.Errorf("label %s = %q, want %q", common.LabelDataUploadUID, pod.Labels[common.LabelDataUploadUID], "uid-12345")
+				}
+				if pod.Annotations[common.AnnotationDataUploadName] != "test-du" {
+					t.Errorf("annotation %s = %q, want %q", common.AnnotationDataUploadName, pod.Annotations[common.AnnotationDataUploadName], "test-du")
 				}
 
 				// Verify pod spec

--- a/internal/controller/pv_rebind.go
+++ b/internal/controller/pv_rebind.go
@@ -81,6 +81,7 @@ func (r *KubeVirtDataUploadReconciler) rebindPVToNamespace(
 	sourceNamespace string,
 	targetNamespace string,
 	dataUploadName string,
+	dataUploadUID string,
 ) (*PVRebindResult, error) {
 	// Step 1: Get the source PVC and its bound PV
 	sourcePVC := &corev1.PersistentVolumeClaim{}
@@ -125,15 +126,20 @@ func (r *KubeVirtDataUploadReconciler) rebindPVToNamespace(
 	}
 
 	// Step 4: Create new PVC in target namespace with volumeName and selector
-	labelKey := common.LabelDataUploadName
-	labelValue := dataUploadName
-	newPVCName := fmt.Sprintf("%s%s", common.ReboundPVCNamePrefix, dataUploadName)
+	// Use LabelDataUploadUID for labels/selector (always ≤ 63 chars) instead of
+	// LabelDataUploadName which can exceed the 63-char Kubernetes label value limit.
+	labelKey := common.LabelDataUploadUID
+	labelValue := dataUploadUID
+	newPVCName := common.SafeResourceName(common.ReboundPVCNamePrefix, dataUploadName)
 	newPVC := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      newPVCName,
 			Namespace: targetNamespace,
 			Labels: map[string]string{
-				common.LabelDataUploadName: dataUploadName,
+				common.LabelDataUploadUID: dataUploadUID,
+			},
+			Annotations: map[string]string{
+				common.AnnotationDataUploadName: dataUploadName,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -323,14 +329,14 @@ func (r *KubeVirtDataUploadReconciler) waitForPVCBound(ctx context.Context, pvcN
 }
 
 // cleanupReboundPVCAndPV deletes the rebound PVC and PV after upload completes.
-// The dataUploadName is used to find the PV by label if the PVC is already gone,
+// The dataUploadUID is used to find the PV by label if the PVC is already gone,
 // preventing storage leakage.
 func (r *KubeVirtDataUploadReconciler) cleanupReboundPVCAndPV(
 	ctx context.Context,
 	logger logr.Logger,
 	pvcName string,
 	pvcNamespace string,
-	dataUploadName string,
+	dataUploadUID string,
 ) error {
 	var pvName string
 
@@ -374,11 +380,11 @@ func (r *KubeVirtDataUploadReconciler) cleanupReboundPVCAndPV(
 	} else {
 		// Find PV by label (PVC was already deleted)
 		pvList := &corev1.PersistentVolumeList{}
-		if err := r.List(ctx, pvList, client.MatchingLabels{common.LabelDataUploadName: dataUploadName}); err != nil {
+		if err := r.List(ctx, pvList, client.MatchingLabels{common.LabelDataUploadUID: dataUploadUID}); err != nil {
 			return fmt.Errorf("failed to list PVs by label: %w", err)
 		}
 		if len(pvList.Items) == 0 {
-			logger.V(1).Info("No PV found with label, already cleaned up", "label", common.LabelDataUploadName, "value", dataUploadName)
+			logger.V(1).Info("No PV found with label, already cleaned up", "label", common.LabelDataUploadUID, "value", dataUploadUID)
 			return nil
 		}
 		if len(pvList.Items) > 1 {
@@ -386,7 +392,7 @@ func (r *KubeVirtDataUploadReconciler) cleanupReboundPVCAndPV(
 		}
 		pv = &pvList.Items[0]
 		pvName = pv.Name
-		logger.Info("Found PV by label", "pv", pvName, "label", common.LabelDataUploadName)
+		logger.Info("Found PV by label", "pv", pvName, "label", common.LabelDataUploadUID)
 	}
 
 	// Set reclaim policy to Delete to ensure underlying storage is cleaned up

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -49,15 +49,20 @@ const (
 	AnnotationDataUploadName = "velero.io/dataupload-name"
 )
 
-// Label keys for resources created by the controller
+// Label keys for resources created by the controller.
+// Note: Kubernetes label values are limited to 63 characters. Use UIDs or
+// hashes (which have fixed length) as label values for lookups; store
+// human-readable names in annotations instead.
 const (
-	// LabelDataUploadName is the label key for the DataUpload name.
-	// Used on datamover pods to track ownership.
-	LabelDataUploadName = "velero.io/dataupload-name"
-
 	// LabelDataUploadUID is the label key for the DataUpload UID.
-	// Used for precise ownership tracking.
+	// UIDs are always 36 characters, safe for label values.
+	// Used for precise ownership tracking and label-based lookups.
 	LabelDataUploadUID = "velero.io/dataupload-uid"
+
+	// LabelVMNameHash is the label key for a hashed VM name on VMBTs.
+	// VM names can exceed the 63-char label limit, so we store a 16-char
+	// hex hash for label-based lookups and the full name in an annotation.
+	LabelVMNameHash = "kubevirt-datamover.io/vm-name-hash"
 
 	// LabelDatamoverPod identifies the type of datamover pod.
 	LabelDatamoverPod = "kubevirt-datamover.io/pod-type"

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+const (
+	// MaxResourceNameLen is the maximum length for Kubernetes resource names
+	// (DNS-1123 subdomain).
+	MaxResourceNameLen = 253
+
+	// MaxLabelValueLen is the maximum length for Kubernetes label values.
+	MaxLabelValueLen = 63
+
+	// hashLen is the length of the truncation hash suffix (8 hex chars).
+	hashLen = 8
+)
+
+// SafeResourceName returns a Kubernetes-safe resource name by combining
+// prefix and name. If the result exceeds 253 chars, the name portion is
+// truncated and a deterministic 8-char hash suffix is appended.
+//
+// The hash is derived from the original (untruncated) name, so the same
+// input always produces the same output (deterministic — safe for Get-by-name).
+func SafeResourceName(prefix, name string) string {
+	fullName := prefix + name
+	if len(fullName) <= MaxResourceNameLen {
+		return fullName
+	}
+	return truncateWithHash(prefix, name, MaxResourceNameLen)
+}
+
+// SafeLabelValue returns a label value that is ≤ 63 chars.
+// If the value exceeds 63 chars, it is truncated with a deterministic
+// 8-char hash suffix to preserve uniqueness for lookups.
+func SafeLabelValue(value string) string {
+	if len(value) <= MaxLabelValueLen {
+		return value
+	}
+	return truncateWithHash("", value, MaxLabelValueLen)
+}
+
+// HashForLabel returns a fixed-length (16 hex char) hash of the input,
+// suitable for use as a label value for grouping/lookup.
+// The same input always produces the same output.
+func HashForLabel(value string) string {
+	hash := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(hash[:8]) // 8 bytes → 16 hex chars
+}
+
+// truncateWithHash truncates prefix+name to fit within maxLen,
+// appending a deterministic hash suffix derived from the original name.
+func truncateWithHash(prefix, name string, maxLen int) string {
+	hash := sha256.Sum256([]byte(name))
+	hashSuffix := hex.EncodeToString(hash[:hashLen/2]) // 4 bytes → 8 hex chars
+
+	// Ensure we have room for at least the hash suffix
+	minRequired := hashLen // just the hash if nothing else fits
+	if len(prefix) > maxLen-minRequired {
+		// Prefix itself is too long — truncate it to make room for hash
+		prefix = prefix[:maxLen-minRequired]
+		prefix = strings.TrimRight(prefix, "-.")
+		return prefix + hashSuffix
+	}
+
+	// Available space for the name portion:
+	// maxLen - len(prefix) - 1 (separator "-") - hashLen
+	available := max(maxLen-len(prefix)-1-hashLen, 0)
+
+	truncated := name
+	if len(name) > available {
+		truncated = name[:available]
+	}
+	// Trim trailing '-' or '.' to keep the name DNS-valid
+	truncated = strings.TrimRight(truncated, "-.")
+
+	if truncated == "" {
+		return prefix + hashSuffix
+	}
+	return prefix + truncated + "-" + hashSuffix
+}

--- a/pkg/common/naming_test.go
+++ b/pkg/common/naming_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSafeResourceName(t *testing.T) {
+	tests := []struct {
+		name       string
+		prefix     string
+		input      string
+		wantExact  string // if set, check exact match
+		wantMaxLen int    // if set, check max length
+		wantPrefix string // if set, check prefix
+	}{
+		{
+			name:      "short name passes through unchanged",
+			prefix:    "kubevirt-dm-",
+			input:     "test-du",
+			wantExact: "kubevirt-dm-test-du",
+		},
+		{
+			name:      "typical DataUpload name passes through",
+			prefix:    "vmb-",
+			input:     "du-my-backup-my-vm-a1b2c3d4",
+			wantExact: "vmb-du-my-backup-my-vm-a1b2c3d4",
+		},
+		{
+			name:       "name at exactly 253 chars passes through",
+			prefix:     "vmb-",
+			input:      strings.Repeat("a", 249),
+			wantMaxLen: 253,
+		},
+		{
+			name:       "name exceeding 253 chars is truncated with hash",
+			prefix:     "kubevirt-dm-pvc-",
+			input:      strings.Repeat("a", 250),
+			wantMaxLen: 253,
+			wantPrefix: "kubevirt-dm-pvc-",
+		},
+		{
+			name:      "empty name with prefix",
+			prefix:    "vmb-",
+			input:     "",
+			wantExact: "vmb-",
+		},
+		{
+			name:       "very long prefix still produces valid result",
+			prefix:     strings.Repeat("p", 250) + "-",
+			input:      "name",
+			wantMaxLen: 253,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SafeResourceName(tt.prefix, tt.input)
+
+			if tt.wantExact != "" && got != tt.wantExact {
+				t.Errorf("SafeResourceName(%q, %q) = %q, want %q", tt.prefix, tt.input, got, tt.wantExact)
+			}
+
+			if tt.wantMaxLen > 0 && len(got) > tt.wantMaxLen {
+				t.Errorf("SafeResourceName(%q, %q) length = %d, want <= %d, got %q",
+					tt.prefix, tt.input, len(got), tt.wantMaxLen, got)
+			}
+
+			if tt.wantPrefix != "" && !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("SafeResourceName(%q, %q) = %q, want prefix %q", tt.prefix, tt.input, got, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestSafeResourceNameDeterministic(t *testing.T) {
+	prefix := "kubevirt-dm-"
+	name := strings.Repeat("long-name-", 30) // 300 chars
+	result1 := SafeResourceName(prefix, name)
+	result2 := SafeResourceName(prefix, name)
+	if result1 != result2 {
+		t.Errorf("SafeResourceName is not deterministic: %q != %q", result1, result2)
+	}
+}
+
+func TestSafeResourceNameDNSValid(t *testing.T) {
+	// Name ending with dashes should have them trimmed
+	prefix := "vmb-"
+	name := strings.Repeat("a", 250) + "---"
+	result := SafeResourceName(prefix, name)
+
+	if len(result) > MaxResourceNameLen {
+		t.Errorf("result length %d exceeds %d", len(result), MaxResourceNameLen)
+	}
+
+	// Should not end with '-' or '.'
+	if strings.HasSuffix(result, "-") || strings.HasSuffix(result, ".") {
+		t.Errorf("result %q ends with invalid DNS character", result)
+	}
+}
+
+func TestSafeLabelValue(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantExact  string
+		wantMaxLen int
+	}{
+		{
+			name:      "short value passes through",
+			input:     "test-value",
+			wantExact: "test-value",
+		},
+		{
+			name:      "UUID passes through (36 chars)",
+			input:     "550e8400-e29b-41d4-a716-446655440000",
+			wantExact: "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name:      "exactly 63 chars passes through",
+			input:     strings.Repeat("a", 63),
+			wantExact: strings.Repeat("a", 63),
+		},
+		{
+			name:       "64 chars is truncated",
+			input:      strings.Repeat("a", 64),
+			wantMaxLen: 63,
+		},
+		{
+			name:       "90-char DataUpload name is truncated",
+			input:      "du-ultra-very-long-backup-name-that-is-over-sixty-three-characters-cirros-test-cont-2-a9ed8aa7",
+			wantMaxLen: 63,
+		},
+		{
+			name:       "very long value is truncated",
+			input:      strings.Repeat("x", 200),
+			wantMaxLen: 63,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SafeLabelValue(tt.input)
+
+			if tt.wantExact != "" && got != tt.wantExact {
+				t.Errorf("SafeLabelValue(%q) = %q, want %q", tt.input, got, tt.wantExact)
+			}
+
+			if tt.wantMaxLen > 0 && len(got) > tt.wantMaxLen {
+				t.Errorf("SafeLabelValue(%q) length = %d, want <= %d, got %q", tt.input, len(got), tt.wantMaxLen, got)
+			}
+		})
+	}
+}
+
+func TestSafeLabelValueDeterministic(t *testing.T) {
+	value := "du-ultra-very-long-backup-name-that-is-over-sixty-three-characters-cirros-test-cont-2-a9ed8aa7"
+	result1 := SafeLabelValue(value)
+	result2 := SafeLabelValue(value)
+	if result1 != result2 {
+		t.Errorf("SafeLabelValue is not deterministic: %q != %q", result1, result2)
+	}
+}
+
+func TestSafeLabelValueDifferentInputs(t *testing.T) {
+	// Two different long values should produce different results
+	value1 := strings.Repeat("a", 100)
+	value2 := strings.Repeat("b", 100)
+	result1 := SafeLabelValue(value1)
+	result2 := SafeLabelValue(value2)
+	if result1 == result2 {
+		t.Errorf("different inputs produced same result: %q", result1)
+	}
+}
+
+func TestHashForLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "short VM name", input: "my-vm"},
+		{name: "long VM name", input: strings.Repeat("long-vm-name-", 10)},
+		{name: "empty", input: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HashForLabel(tt.input)
+			if len(got) != 16 {
+				t.Errorf("HashForLabel(%q) length = %d, want 16", tt.input, len(got))
+			}
+			// Deterministic
+			if got2 := HashForLabel(tt.input); got != got2 {
+				t.Errorf("HashForLabel is not deterministic: %q != %q", got, got2)
+			}
+		})
+	}
+
+	// Different inputs produce different hashes
+	h1 := HashForLabel("vm-1")
+	h2 := HashForLabel("vm-2")
+	if h1 == h2 {
+		t.Errorf("different inputs produced same hash: %q", h1)
+	}
+}

--- a/pkg/uploader/run.go
+++ b/pkg/uploader/run.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/migtools/kubevirt-datamover-controller/pkg/common"
 	velero "github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -156,7 +157,7 @@ func LoadConfigFromEnv() (*UploaderConfig, error) {
 		config.BackupType = "full"
 	}
 	if config.VMBTName == "" && config.VMName != "" {
-		config.VMBTName = "vmbt-" + config.VMName
+		config.VMBTName = common.SafeResourceName("vmbt-", config.VMName)
 	}
 
 	// Validate required fields


### PR DESCRIPTION
## Requirements

This PR requires plugin to be updated as well, however plugin code must be updated after this one is merged.
Plugin PR: https://github.com/migtools/kubevirt-datamover-plugin/pull/6

## feat: Add label-safe naming utilities and detect deleted VMBTs

  Kubernetes label values are limited to 63 characters, which can be
  exceeded by DataUpload names and VM names. This adds SafeResourceName,
  SafeLabelValue, and HashForLabel utilities and applies them to
  resource creation and label usage.

  Key changes:
  - Remove LabelDataUploadName; use LabelDataUploadUID for label-based lookups on pods and rebound PVCs (UIDs are always 36 chars)
  - Add LabelVMNameHash for VMBT ownership lookup (16-char hex hash replaces raw VM name which can exceed 63 chars)
  - Use SafeResourceName for deterministic resource names to guard against the 253-char resource name limit

  Additionally, detect and fail DataUploads whose VMBTs were deleted
  by concurrent reconciles for the same VM:
  - Check VMBT existence when VMB status is nil (KubeVirt hasn't processed it yet)
  - Check VMBT existence when VMB is stuck initializing (Initializing=True, Progressing=False, no Done condition)
  - Add race condition guard: requeue when VMBT annotation is set but VMB is not yet visible in the cache

## Tests performed
Ran number of backups with breaking chain and various length of the backups (even way above 63 chars). All works fine.

<img width="2642" height="420" alt="image" src="https://github.com/user-attachments/assets/88673419-ca29-49a8-8434-168c8bd0417e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition where VM backup tracker might be deleted prematurely when backup metadata visibility is delayed
  * Added validation checks to prevent infinite requeue loops during concurrent resource operations
  * Improved error handling when referenced resources are missing

* **Refactor**
  * Enhanced resource naming system to safely handle long VM names through deterministic hashing
  * Updated resource tracking to use unique identifiers instead of name-based references
  * Reorganized metadata with improved label and annotation usage patterns

* **Tests**
  * Added coverage for race condition and resource visibility scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->