### PR TITLE
fix: serialize concurrent DataUploads per VM to prevent VMBT destruction

### DIFF
--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -234,6 +234,20 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 		return ctrl.Result{}, nil
 	}
 
+	// Serialize per VM: only the oldest DataUpload for a given VM proceeds.
+	// All younger DUs wait until the older one reaches a terminal phase (Completed/Failed).
+	// This ensures the previous backup's checkpoint is uploaded to S3 before the
+	// next backup starts, enabling incremental backups.
+	shouldWait, blockingDU, err := r.hasOlderActiveDUForVM(ctx, du)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if shouldWait {
+		logger.Info("Another DataUpload is still active for this VM, waiting",
+			"vm", vmRef.Name, "blockingDU", blockingDU)
+		return ctrl.Result{RequeueAfter: RequeueAfterLong}, nil
+	}
+
 	// Step 0: Verify BSL exists and is Available before creating any resources.
 	// BSL must be in Available phase — if it's not, fail immediately rather than
 	// creating resources (PVC, VMBT, VMB) that will be wasted.
@@ -999,16 +1013,40 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 
 // prepareVMBackupTracker creates a VirtualMachineBackupTracker for the VM,
 // restoring the LatestCheckpoint from the archived VMBT in S3 if available.
-// Any existing VMBT is deleted first to avoid conflicts (S3 is the source of truth).
+// Existing VMBTs are deleted first unless they are still referenced by an active
+// (non-terminal) VMB, to avoid destroying VMBTs used by concurrent DataUploads.
 func (r *KubeVirtDataUploadReconciler) prepareVMBackupTracker(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, vmName, vmNamespace string) (*kubevirtbackupv1alpha1.VirtualMachineBackupTracker, error) {
-	// Delete any existing VMBT for this VM before creating a new one.
-	// This ensures we always start from the state restored from S3.
+	// Delete existing VMBTs for this VM before creating a new one, but only if
+	// they are not still referenced by an active (non-terminal) VMB. This prevents
+	// concurrent DataUploads from destroying each other's VMBTs.
 	existingVMBTList := &kubevirtbackupv1alpha1.VirtualMachineBackupTrackerList{}
 	if err := r.List(ctx, existingVMBTList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelVMNameHash: common.HashForLabel(vmName)}); err != nil {
 		return nil, fmt.Errorf("failed to list existing VMBTs: %w", err)
 	}
+
+	// Pre-fetch all VMBs in the namespace to check references
+	allVMBs := &kubevirtbackupv1alpha1.VirtualMachineBackupList{}
+	if err := r.List(ctx, allVMBs, client.InNamespace(vmNamespace)); err != nil {
+		return nil, fmt.Errorf("failed to list VMBs: %w", err)
+	}
+
 	for i := range existingVMBTList.Items {
 		vmbtToDelete := &existingVMBTList.Items[i]
+
+		// Check if any non-terminal VMB still references this VMBT
+		referenced := false
+		for j := range allVMBs.Items {
+			if allVMBs.Items[j].Spec.Source.Name == vmbtToDelete.Name && !isVMBTerminal(&allVMBs.Items[j]) {
+				referenced = true
+				break
+			}
+		}
+		if referenced {
+			logger.Info("Skipping VMBT deletion, still referenced by active VMB",
+				"vmbt", vmbtToDelete.Name)
+			continue
+		}
+
 		logger.Info("Deleting existing VMBT before recreation", "vmbt", vmbtToDelete.Name)
 		if err := r.Delete(ctx, vmbtToDelete); err != nil && !errors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to delete existing VMBT %s: %w", vmbtToDelete.Name, err)
@@ -1237,6 +1275,93 @@ func (r *KubeVirtDataUploadReconciler) findVMBForDataUpload(ctx context.Context,
 		return nil, fmt.Errorf("found multiple VirtualMachineBackups for DataUpload %s", du.Name)
 	}
 	return &vmbList.Items[0], nil
+}
+
+// isVMBTerminal returns true if the VMB has reached a terminal state:
+// Done=True (success) or Done=False + Progressing=False (failure).
+func isVMBTerminal(vmb *kubevirtbackupv1alpha1.VirtualMachineBackup) bool {
+	if vmb.Status == nil {
+		return false
+	}
+	var doneCond, progressingCond *kubevirtbackupv1alpha1.Condition
+	for i := range vmb.Status.Conditions {
+		switch vmb.Status.Conditions[i].Type {
+		case kubevirtbackupv1alpha1.ConditionDone:
+			doneCond = &vmb.Status.Conditions[i]
+		case kubevirtbackupv1alpha1.ConditionProgressing:
+			progressingCond = &vmb.Status.Conditions[i]
+		}
+	}
+	if doneCond == nil {
+		return false
+	}
+	if doneCond.Status == corev1.ConditionTrue {
+		return true
+	}
+	return progressingCond != nil && progressingCond.Status == corev1.ConditionFalse
+}
+
+// hasOlderActiveDUForVM checks if an older DataUpload targeting the same VM is
+// still in an active phase (Accepted, Prepared, InProgress). This serializes
+// backups per VM so that each backup completes (including S3 upload) before the
+// next one starts, enabling incremental backups through checkpoint chaining.
+// The oldest DU (by CreationTimestamp, then UID) always wins.
+func (r *KubeVirtDataUploadReconciler) hasOlderActiveDUForVM(ctx context.Context, du *velerov2alpha1.DataUpload) (bool, string, error) {
+	vmName := du.Annotations[common.AnnotationVMName]
+	if vmName == "" {
+		return false, "", nil
+	}
+	vmNamespace := du.Annotations[common.AnnotationVMNamespace]
+	if vmNamespace == "" {
+		vmNamespace = du.Spec.SourceNamespace
+	}
+
+	duList := &velerov2alpha1.DataUploadList{}
+	if err := r.List(ctx, duList, client.InNamespace(du.Namespace)); err != nil {
+		return false, "", fmt.Errorf("failed to list DataUploads: %w", err)
+	}
+
+	for i := range duList.Items {
+		other := &duList.Items[i]
+		if other.UID == du.UID {
+			continue
+		}
+		if other.Spec.DataMover != common.DataMoverKubeVirt {
+			continue
+		}
+
+		// Must target the same VM
+		otherVMName := other.Annotations[common.AnnotationVMName]
+		if otherVMName != vmName {
+			continue
+		}
+		otherVMNs := other.Annotations[common.AnnotationVMNamespace]
+		if otherVMNs == "" {
+			otherVMNs = other.Spec.SourceNamespace
+		}
+		if otherVMNs != vmNamespace {
+			continue
+		}
+
+		// Must be in an active (non-terminal) phase
+		switch other.Status.Phase {
+		case "", velerov2alpha1.DataUploadPhaseNew,
+			velerov2alpha1.DataUploadPhaseAccepted,
+			velerov2alpha1.DataUploadPhasePrepared,
+			velerov2alpha1.DataUploadPhaseInProgress:
+		default:
+			continue
+		}
+
+		// Older DU takes priority; same timestamp uses UID as tiebreaker
+		if other.CreationTimestamp.Before(&du.CreationTimestamp) {
+			return true, other.Name, nil
+		}
+		if other.CreationTimestamp.Equal(&du.CreationTimestamp) && string(other.UID) < string(du.UID) {
+			return true, other.Name, nil
+		}
+	}
+	return false, "", nil
 }
 
 // getVeleroBackupName extracts the Velero backup name from DataUpload labels

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/migtools/kubevirt-datamover-controller/pkg/common"
@@ -935,6 +936,478 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsVMBTerminal(t *testing.T) {
+	tests := []struct {
+		name     string
+		vmb      *kubevirtbackupv1alpha1.VirtualMachineBackup
+		expected bool
+	}{
+		{
+			name: "nil status is not terminal",
+			vmb: &kubevirtbackupv1alpha1.VirtualMachineBackup{
+				Status: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "no conditions is not terminal",
+			vmb: &kubevirtbackupv1alpha1.VirtualMachineBackup{
+				Status: &kubevirtbackupv1alpha1.VirtualMachineBackupStatus{
+					Conditions: []kubevirtbackupv1alpha1.Condition{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Done=True is terminal (success)",
+			vmb: &kubevirtbackupv1alpha1.VirtualMachineBackup{
+				Status: &kubevirtbackupv1alpha1.VirtualMachineBackupStatus{
+					Conditions: []kubevirtbackupv1alpha1.Condition{
+						{Type: kubevirtbackupv1alpha1.ConditionDone, Status: corev1.ConditionTrue},
+						{Type: kubevirtbackupv1alpha1.ConditionProgressing, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Done=False + Progressing=False is terminal (failure)",
+			vmb: &kubevirtbackupv1alpha1.VirtualMachineBackup{
+				Status: &kubevirtbackupv1alpha1.VirtualMachineBackupStatus{
+					Conditions: []kubevirtbackupv1alpha1.Condition{
+						{Type: kubevirtbackupv1alpha1.ConditionDone, Status: corev1.ConditionFalse},
+						{Type: kubevirtbackupv1alpha1.ConditionProgressing, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Progressing=True + Done=False is not terminal (in progress)",
+			vmb: &kubevirtbackupv1alpha1.VirtualMachineBackup{
+				Status: &kubevirtbackupv1alpha1.VirtualMachineBackupStatus{
+					Conditions: []kubevirtbackupv1alpha1.Condition{
+						{Type: kubevirtbackupv1alpha1.ConditionDone, Status: corev1.ConditionFalse},
+						{Type: kubevirtbackupv1alpha1.ConditionProgressing, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Initializing=True only is not terminal",
+			vmb: &kubevirtbackupv1alpha1.VirtualMachineBackup{
+				Status: &kubevirtbackupv1alpha1.VirtualMachineBackupStatus{
+					Conditions: []kubevirtbackupv1alpha1.Condition{
+						{Type: kubevirtbackupv1alpha1.ConditionInitializing, Status: corev1.ConditionTrue},
+						{Type: kubevirtbackupv1alpha1.ConditionProgressing, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Done=False without Progressing is not terminal",
+			vmb: &kubevirtbackupv1alpha1.VirtualMachineBackup{
+				Status: &kubevirtbackupv1alpha1.VirtualMachineBackupStatus{
+					Conditions: []kubevirtbackupv1alpha1.Condition{
+						{Type: kubevirtbackupv1alpha1.ConditionDone, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isVMBTerminal(tt.vmb)
+			if got != tt.expected {
+				t.Errorf("isVMBTerminal() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasOlderActiveDUForVM(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+
+	vmName := "test-vm"
+	vmNamespace := "vm-ns"
+	oadpNs := "openshift-adp"
+
+	// Use second-precision times to avoid nanosecond issues with fake client
+	baseTime := metav1.NewTime(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	olderTime := metav1.NewTime(time.Date(2026, 1, 1, 11, 59, 0, 0, time.UTC))
+	newerTime := metav1.NewTime(time.Date(2026, 1, 1, 12, 1, 0, 0, time.UTC))
+
+	makeDU := func(name string, uid types.UID, phase velerov2alpha1.DataUploadPhase, creationTime metav1.Time, vm, vmNs string) *velerov2alpha1.DataUpload {
+		return &velerov2alpha1.DataUpload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         oadpNs,
+				UID:               uid,
+				CreationTimestamp: creationTime,
+				Annotations: map[string]string{
+					common.AnnotationVMName:      vm,
+					common.AnnotationVMNamespace: vmNs,
+				},
+			},
+			Spec: velerov2alpha1.DataUploadSpec{
+				DataMover:       common.DataMoverKubeVirt,
+				SourceNamespace: vmNs,
+			},
+			Status: velerov2alpha1.DataUploadStatus{
+				Phase: phase,
+			},
+		}
+	}
+
+	// The DU we're testing (current)
+	currentDU := makeDU("du-current", "current-uid", velerov2alpha1.DataUploadPhaseAccepted, baseTime, vmName, vmNamespace)
+
+	tests := []struct {
+		name        string
+		otherDUs    []client.Object
+		wantWait    bool
+		wantBlocked string
+	}{
+		{
+			name:     "no other DUs",
+			otherDUs: []client.Object{},
+			wantWait: false,
+		},
+		{
+			name: "other DU targets different VM",
+			otherDUs: []client.Object{
+				makeDU("du-other", "other-uid", velerov2alpha1.DataUploadPhaseAccepted, olderTime, "different-vm", vmNamespace),
+			},
+			wantWait: false,
+		},
+		{
+			name: "other DU targets same VM in different namespace",
+			otherDUs: []client.Object{
+				makeDU("du-other", "other-uid", velerov2alpha1.DataUploadPhaseAccepted, olderTime, vmName, "other-ns"),
+			},
+			wantWait: false,
+		},
+		{
+			name: "older DU in Completed phase (terminal)",
+			otherDUs: []client.Object{
+				makeDU("du-other", "other-uid", velerov2alpha1.DataUploadPhaseCompleted, olderTime, vmName, vmNamespace),
+			},
+			wantWait: false,
+		},
+		{
+			name: "older DU in Failed phase (terminal)",
+			otherDUs: []client.Object{
+				makeDU("du-other", "other-uid", velerov2alpha1.DataUploadPhaseFailed, olderTime, vmName, vmNamespace),
+			},
+			wantWait: false,
+		},
+		{
+			name: "older DU in New phase — should wait",
+			otherDUs: []client.Object{
+				makeDU("du-other", "other-uid", velerov2alpha1.DataUploadPhaseNew, olderTime, vmName, vmNamespace),
+			},
+			wantWait:    true,
+			wantBlocked: "du-other",
+		},
+		{
+			name: "older DU in Accepted phase — should wait",
+			otherDUs: []client.Object{
+				makeDU("du-other", "other-uid", velerov2alpha1.DataUploadPhaseAccepted, olderTime, vmName, vmNamespace),
+			},
+			wantWait:    true,
+			wantBlocked: "du-other",
+		},
+		{
+			name: "older DU in Prepared phase — should wait",
+			otherDUs: []client.Object{
+				makeDU("du-other", "other-uid", velerov2alpha1.DataUploadPhasePrepared, olderTime, vmName, vmNamespace),
+			},
+			wantWait:    true,
+			wantBlocked: "du-other",
+		},
+		{
+			name: "older DU in InProgress phase — should wait",
+			otherDUs: []client.Object{
+				makeDU("du-other", "other-uid", velerov2alpha1.DataUploadPhaseInProgress, olderTime, vmName, vmNamespace),
+			},
+			wantWait:    true,
+			wantBlocked: "du-other",
+		},
+		{
+			name: "newer DU in Accepted phase — should NOT wait",
+			otherDUs: []client.Object{
+				makeDU("du-other", "other-uid", velerov2alpha1.DataUploadPhaseAccepted, newerTime, vmName, vmNamespace),
+			},
+			wantWait: false,
+		},
+		{
+			name: "same timestamp, lower UID — should wait",
+			otherDUs: []client.Object{
+				makeDU("du-other", "aaa-uid", velerov2alpha1.DataUploadPhaseAccepted, baseTime, vmName, vmNamespace),
+			},
+			wantWait:    true,
+			wantBlocked: "du-other",
+		},
+		{
+			name: "same timestamp, higher UID — should NOT wait",
+			otherDUs: []client.Object{
+				makeDU("du-other", "zzz-uid", velerov2alpha1.DataUploadPhaseAccepted, baseTime, vmName, vmNamespace),
+			},
+			wantWait: false,
+		},
+		{
+			name: "non-kubevirt DU is ignored",
+			otherDUs: []client.Object{
+				func() *velerov2alpha1.DataUpload {
+					du := makeDU("du-other", "other-uid", velerov2alpha1.DataUploadPhaseAccepted, olderTime, vmName, vmNamespace)
+					du.Spec.DataMover = "kopia"
+					return du
+				}(),
+			},
+			wantWait: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := append([]client.Object{currentDU.DeepCopy()}, tt.otherDUs...)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				Build()
+
+			r := &KubeVirtDataUploadReconciler{
+				Client:        fakeClient,
+				Scheme:        scheme,
+				Log:           logr.Discard(),
+				OADPNamespace: oadpNs,
+			}
+
+			shouldWait, blockingDU, err := r.hasOlderActiveDUForVM(context.Background(), currentDU.DeepCopy())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if shouldWait != tt.wantWait {
+				t.Errorf("hasOlderActiveDUForVM() shouldWait = %v, want %v", shouldWait, tt.wantWait)
+			}
+			if tt.wantWait && blockingDU != tt.wantBlocked {
+				t.Errorf("hasOlderActiveDUForVM() blockingDU = %q, want %q", blockingDU, tt.wantBlocked)
+			}
+		})
+	}
+}
+
+func TestHandleAccepted_RequeuesWhenOlderDUActive(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = velerov1.AddToScheme(scheme)
+
+	vmName := "test-vm"
+	vmNamespace := "vm-ns"
+	oadpNs := "openshift-adp"
+
+	olderTime := metav1.NewTime(time.Date(2026, 1, 1, 11, 59, 0, 0, time.UTC))
+	newerTime := metav1.NewTime(time.Date(2026, 1, 1, 12, 1, 0, 0, time.UTC))
+
+	// DU-1 (older) is in InProgress — still uploading to S3
+	du1 := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "du-1",
+			Namespace:         oadpNs,
+			UID:               types.UID("du-1-uid"),
+			CreationTimestamp: olderTime,
+			Annotations: map[string]string{
+				common.AnnotationVMName:      vmName,
+				common.AnnotationVMNamespace: vmNamespace,
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover:       common.DataMoverKubeVirt,
+			SourceNamespace: vmNamespace,
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseInProgress,
+		},
+	}
+
+	// DU-2 (newer) just entered Accepted — should wait for DU-1
+	du2 := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "du-2",
+			Namespace:         oadpNs,
+			UID:               types.UID("du-2-uid"),
+			CreationTimestamp: newerTime,
+			Annotations: map[string]string{
+				common.AnnotationVMName:      vmName,
+				common.AnnotationVMNamespace: vmNamespace,
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover:             common.DataMoverKubeVirt,
+			BackupStorageLocation: "default",
+			SourceNamespace:       vmNamespace,
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseAccepted,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du1, du2).
+		Build()
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		OADPNamespace: oadpNs,
+	}
+
+	result, err := r.handleAccepted(context.Background(), logr.Discard(), du2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.RequeueAfter != RequeueAfterLong {
+		t.Errorf("expected RequeueAfter=%v (RequeueAfterLong), got %v", RequeueAfterLong, result.RequeueAfter)
+	}
+}
+
+func TestHandleAccepted_ProceedsWhenOlderDUCompleted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = velerov1.AddToScheme(scheme)
+
+	vmName := "test-vm"
+	vmNamespace := "vm-ns"
+	oadpNs := "openshift-adp"
+
+	olderTime := metav1.NewTime(time.Date(2026, 1, 1, 11, 59, 0, 0, time.UTC))
+	newerTime := metav1.NewTime(time.Date(2026, 1, 1, 12, 1, 0, 0, time.UTC))
+
+	// DU-1 (older) is Completed — should not block
+	du1 := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "du-1",
+			Namespace:         oadpNs,
+			UID:               types.UID("du-1-uid"),
+			CreationTimestamp: olderTime,
+			Annotations: map[string]string{
+				common.AnnotationVMName:      vmName,
+				common.AnnotationVMNamespace: vmNamespace,
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover:       common.DataMoverKubeVirt,
+			SourceNamespace: vmNamespace,
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseCompleted,
+		},
+	}
+
+	// DU-1's old VMBT still exists in the VM namespace
+	vmbt1 := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vmbt-test-vm-aaa",
+			Namespace: vmNamespace,
+			Labels: map[string]string{
+				common.LabelVMNameHash:    common.HashForLabel(vmName),
+				common.LabelDataUploadUID: string(du1.UID),
+			},
+		},
+	}
+
+	// DU-2 (newer) — should proceed since DU-1 is terminal
+	du2 := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "du-2",
+			Namespace:         oadpNs,
+			UID:               types.UID("du-2-uid"),
+			CreationTimestamp: newerTime,
+			Annotations: map[string]string{
+				common.AnnotationVMName:      vmName,
+				common.AnnotationVMNamespace: vmNamespace,
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover:             common.DataMoverKubeVirt,
+			BackupStorageLocation: "default",
+			SourceNamespace:       vmNamespace,
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseAccepted,
+		},
+	}
+
+	bsl := &velerov1.BackupStorageLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: oadpNs,
+		},
+		Spec: velerov1.BackupStorageLocationSpec{
+			Provider: "aws",
+			StorageType: velerov1.StorageType{
+				ObjectStorage: &velerov1.ObjectStorageLocation{Bucket: "b", Prefix: "v"},
+			},
+			Config:     map[string]string{"region": "us-east-1"},
+			Credential: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "c"}, Key: "cloud"},
+		},
+		Status: velerov1.BackupStorageLocationStatus{Phase: velerov1.BackupStorageLocationPhaseAvailable},
+	}
+
+	// Temp PVC for DU-2
+	tempPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-backup-du-2",
+			Namespace: vmNamespace,
+			Labels:    map[string]string{common.LabelDataUploadUID: "du-2-uid"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du1, du2, bsl, tempPVC, vmbt1).
+		Build()
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		OADPNamespace: oadpNs,
+	}
+
+	_, err := r.handleAccepted(context.Background(), logr.Discard(), du2)
+
+	// DU-2 should NOT be blocked — DU-1 is Completed (terminal).
+	// It will proceed into prepareVMBackupTracker, which will fail because
+	// BSL credentials aren't fully set up in this test. That's fine — we're
+	// testing that the serialization guard does NOT block.
+	// The important assertion is that DU-1's VMBT gets deleted (normal cleanup).
+	deletedVMBT := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{}
+	getErr := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: vmbt1.Name, Namespace: vmNamespace,
+	}, deletedVMBT)
+
+	// prepareVMBackupTracker should have deleted DU-1's old VMBT
+	if getErr == nil {
+		t.Error("expected DU-1's VMBT to be deleted by prepareVMBackupTracker, but it still exists")
+	}
+	// We don't care about the error from handleAccepted itself — it may fail
+	// on BSL credential lookup. The point is it got past the serialization guard.
+	_ = err
 }
 
 // strPtr returns a pointer to the given string
@@ -5112,6 +5585,197 @@ func TestPrepareVMBackupTracker_DeletesExisting(t *testing.T) {
 	if vmbt.Labels[common.LabelVMNameHash] != common.HashForLabel(vmName) {
 		t.Errorf("expected new VMBT to have label %s, got %q",
 			common.LabelVMNameHash, vmbt.Labels[common.LabelVMNameHash])
+	}
+}
+
+func TestPrepareVMBackupTracker_SkipsReferencedVMBT(t *testing.T) {
+	// A VMBT referenced by a non-terminal VMB must NOT be deleted.
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	vmName := "test-vm"
+	vmNamespace := "test-ns"
+
+	du := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "du-new",
+			Namespace: vmNamespace,
+			UID:       types.UID("du-new-uid"),
+			Annotations: map[string]string{
+				common.AnnotationVMName:      vmName,
+				common.AnnotationVMNamespace: vmNamespace,
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover: common.DataMoverKubeVirt,
+		},
+	}
+
+	// VMBT from another DU, still referenced by an active VMB
+	otherVMBT := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vmbt-test-vm-other",
+			Namespace: vmNamespace,
+			Labels: map[string]string{
+				common.LabelVMNameHash:    common.HashForLabel(vmName),
+				common.LabelDataUploadUID: "other-du-uid",
+			},
+		},
+		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
+			Source: corev1.TypedLocalObjectReference{
+				APIGroup: strPtr("kubevirt.io"),
+				Kind:     "VirtualMachine",
+				Name:     vmName,
+			},
+		},
+	}
+
+	// Active (non-terminal) VMB referencing the other VMBT
+	activeVMB := &kubevirtbackupv1alpha1.VirtualMachineBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vmb-other-du",
+			Namespace: vmNamespace,
+			Labels: map[string]string{
+				common.LabelDataUploadUID: "other-du-uid",
+			},
+		},
+		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{
+			Source: corev1.TypedLocalObjectReference{
+				APIGroup: strPtr("backup.kubevirt.io"),
+				Kind:     "VirtualMachineBackupTracker",
+				Name:     otherVMBT.Name,
+			},
+		},
+		// nil status = non-terminal
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du, otherVMBT, activeVMB).
+		Build()
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		OADPNamespace: vmNamespace,
+	}
+
+	vmbt, err := r.prepareVMBackupTracker(context.Background(), logr.Discard(), du, vmName, vmNamespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// New VMBT should be created
+	if vmbt == nil {
+		t.Fatal("expected new VMBT to be created")
+	}
+	if vmbt.Name == otherVMBT.Name {
+		t.Error("new VMBT should not be the same object as the protected VMBT")
+	}
+
+	// The other VMBT must NOT be deleted
+	preserved := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: otherVMBT.Name, Namespace: vmNamespace,
+	}, preserved); err != nil {
+		t.Errorf("referenced VMBT was deleted when it should have been preserved: %v", err)
+	}
+}
+
+func TestPrepareVMBackupTracker_DeletesVMBTWithTerminalVMB(t *testing.T) {
+	// A VMBT referenced by a terminal VMB (Done=True) should be deleted normally.
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	vmName := "test-vm"
+	vmNamespace := "test-ns"
+
+	du := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "du-new",
+			Namespace: vmNamespace,
+			UID:       types.UID("du-new-uid"),
+			Annotations: map[string]string{
+				common.AnnotationVMName:      vmName,
+				common.AnnotationVMNamespace: vmNamespace,
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover: common.DataMoverKubeVirt,
+		},
+	}
+
+	// VMBT from a completed DU
+	oldVMBT := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vmbt-test-vm-done",
+			Namespace: vmNamespace,
+			Labels: map[string]string{
+				common.LabelVMNameHash:    common.HashForLabel(vmName),
+				common.LabelDataUploadUID: "old-du-uid",
+			},
+		},
+		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
+			Source: corev1.TypedLocalObjectReference{
+				APIGroup: strPtr("kubevirt.io"),
+				Kind:     "VirtualMachine",
+				Name:     vmName,
+			},
+		},
+	}
+
+	// Terminal VMB (Done=True) referencing the old VMBT
+	terminalVMB := &kubevirtbackupv1alpha1.VirtualMachineBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vmb-old-du",
+			Namespace: vmNamespace,
+			Labels: map[string]string{
+				common.LabelDataUploadUID: "old-du-uid",
+			},
+		},
+		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupSpec{
+			Source: corev1.TypedLocalObjectReference{
+				APIGroup: strPtr("backup.kubevirt.io"),
+				Kind:     "VirtualMachineBackupTracker",
+				Name:     oldVMBT.Name,
+			},
+		},
+		Status: &kubevirtbackupv1alpha1.VirtualMachineBackupStatus{
+			Conditions: []kubevirtbackupv1alpha1.Condition{
+				{Type: kubevirtbackupv1alpha1.ConditionDone, Status: corev1.ConditionTrue},
+				{Type: kubevirtbackupv1alpha1.ConditionProgressing, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du, oldVMBT, terminalVMB).
+		Build()
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		OADPNamespace: vmNamespace,
+	}
+
+	_, err := r.prepareVMBackupTracker(context.Background(), logr.Discard(), du, vmName, vmNamespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The old VMBT should be deleted (its VMB is terminal)
+	deleted := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: oldVMBT.Name, Namespace: vmNamespace,
+	}, deleted); err == nil {
+		t.Error("expected old VMBT to be deleted (VMB is terminal), but it still exists")
 	}
 }
 

--- a/pkg/uploader/run.go
+++ b/pkg/uploader/run.go
@@ -31,13 +31,17 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/migtools/kubevirt-datamover-controller/pkg/common"
 	velero "github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kubevirtbackupv1alpha1 "kubevirt.io/api/backup/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	restcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
+
+const apiGroupKubeVirt = "kubevirt.io"
 
 // Helper functions for working with velero.ObjectStore interface
 
@@ -568,8 +572,16 @@ func archiveKubeResources(
 		if err := k8sClient.Get(ctx, types.NamespacedName{
 			Name: cfg.VMBTName, Namespace: cfg.VMNamespace,
 		}, vmbt); err != nil {
-			return nil, fmt.Errorf("failed to fetch VMBT %s/%s: %w",
-				cfg.VMNamespace, cfg.VMBTName, err)
+			if !apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("failed to fetch VMBT %s/%s: %w",
+					cfg.VMNamespace, cfg.VMBTName, err)
+			}
+			// VMBT was deleted by a concurrent DataUpload's prepareVMBackupTracker.
+			// Reconstruct a minimal VMBT for archiving — the only field the controller
+			// reads back is Status.LatestCheckpoint, which we set below anyway.
+			logger.Info("VMBT not found in cluster, reconstructing for archival",
+				"vmbt", cfg.VMBTName)
+			vmbt = reconstructVMBT(cfg)
 		}
 
 		// Set LatestCheckpoint to the current checkpoint so the next backup
@@ -599,6 +611,28 @@ func archiveKubeResources(
 	}
 
 	return paths, nil
+}
+
+// reconstructVMBT builds a minimal VirtualMachineBackupTracker from the uploader
+// config. Used when the VMBT was deleted from the cluster by a concurrent
+// DataUpload before the datamover pod could archive it. The only field the
+// controller reads from the archived vmbt.json is Status.LatestCheckpoint,
+// which is set by the caller after this function returns.
+func reconstructVMBT(cfg *UploaderConfig) *kubevirtbackupv1alpha1.VirtualMachineBackupTracker {
+	apiGroup := apiGroupKubeVirt
+	return &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.VMBTName,
+			Namespace: cfg.VMNamespace,
+		},
+		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
+			Source: corev1.TypedLocalObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     "VirtualMachine",
+				Name:     cfg.VMName,
+			},
+		},
+	}
 }
 
 // cleanupKubeResources deletes VMB and VMBT CRs from the cluster after they have

--- a/pkg/uploader/run_test.go
+++ b/pkg/uploader/run_test.go
@@ -1476,7 +1476,7 @@ func TestArchiveKubeResources(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "fails when VMBT not found (fatal)",
+			name: "reconstructs VMBT when not found in cluster",
 			config: &UploaderConfig{
 				BSLBucket:      "test-bucket",
 				VMName:         "test-vm",
@@ -1500,7 +1500,30 @@ func TestArchiveKubeResources(t *testing.T) {
 					},
 				},
 			},
-			expectError: true,
+			expectError: false,
+			validateResult: func(t *testing.T, store *MockObjectStore, paths *archivedPaths) {
+				if paths.VMBTObjectPath == "" {
+					t.Error("expected VMBT to be archived even when reconstructed")
+				}
+				// Verify the reconstructed VMBT was archived with correct checkpoint
+				data, err := getObjectBytes(store, "test-bucket", paths.VMBTObjectPath)
+				if err != nil {
+					t.Fatalf("failed to read archived VMBT: %v", err)
+				}
+				var vmbt kubevirtbackupv1alpha1.VirtualMachineBackupTracker
+				if err := json.Unmarshal(data, &vmbt); err != nil {
+					t.Fatalf("failed to unmarshal archived VMBT: %v", err)
+				}
+				if vmbt.Name != "vmbt-nonexistent" {
+					t.Errorf("reconstructed VMBT name = %q, want %q", vmbt.Name, "vmbt-nonexistent")
+				}
+				if vmbt.Status == nil || vmbt.Status.LatestCheckpoint == nil {
+					t.Fatal("expected LatestCheckpoint to be set on reconstructed VMBT")
+				}
+				if vmbt.Status.LatestCheckpoint.Name != "cp-001" {
+					t.Errorf("LatestCheckpoint = %q, want %q", vmbt.Status.LatestCheckpoint.Name, "cp-001")
+				}
+			},
 		},
 		{
 			name: "handles empty VMBName and VMBTName",


### PR DESCRIPTION
Fixes #28 

  ### Problem                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                         
When multiple Velero backups run concurrently for the same VM, each DataUpload's `prepareVMBackupTracker` deletes ALL VMBTs for that VM before creating its own. This destroys VMBTs that other DataUploads' VMBs are actively using, leaving those VMBs permanently stuck with `"BackupTracker no longer exists"`.                                                                                                                                                                                                                                                  

### Root cause

The VMBT deletion loop in `prepareVMBackupTracker` uses a label selector (`LabelVMNameHash`) that matches all VMBTs for a VM, regardless of which DataUpload owns them. With `MaxConcurrentReconciles=3`, multiple DataUploads can enter this function simultaneously and delete each other's VMBTs.

### Fix

Three layers, each targeting a different part of the problem:

**1. Serialize backups per VM (`handleAccepted`)**

A new `hasOlderActiveDUForVM` guard at the top of `handleAccepted` lists all DataUploads in the namespace and checks if an older one (by `CreationTimestamp`, then UID as tiebreaker) targeting the same VM is still in an active phase (`Accepted`, `Prepared`, or `InProgress`). If found, the current DataUpload requeues with a 30s delay. This ensures only one DataUpload at a time creates resources for a given VM, which also enables incremental backups — each backup completes its S3 upload before the next one starts, so the checkpoint chain is preserved.

**2. Skip referenced VMBTs (`prepareVMBackupTracker`)**

  Defense-in-depth for the TOCTOU race window where two reconcilers pass the serialization check simultaneously. Before deleting a VMBT, the deletion loop now pre-fetches all VMBs in the namespace and checks if any non-terminal VMB (using `isVMBTerminal` helper) still references that VMBT via `Spec.Source.Name`. If referenced, the VMBT is skipped with a log message instead of deleted.

  **3. Reconstruct VMBT in datamover pod (`pkg/uploader/run.go`)**

When the datamover pod (running in `InProgress` phase) tries to archive the VMBT to S3 but finds it was already deleted, it now reconstructs a minimal VMBT from the uploader config instead of failing. This is safe because the only field the controller reads from the archived `vmbt.json` is `Status.LatestCheckpoint`, which the pod always overwrites with the current checkpoint before archiving.

## Tests after fixes

Performed 2 tests:

### First was to create 15 backups all at once, all successfully finished

<img width="1886" height="880" alt="image" src="https://github.com/user-attachments/assets/13c4463a-5486-4fd4-a197-1f064e8abdc2" />

### Second test
Was similar to previous, but after first set of backups were done, another 20 backups were created all at once and in the middle of their work manual removal of one of the s3 backups was performed to ensure next one that was queued will be a full backup meaning that the chain breakage and follow up backups are properly discovering chains.

This test was also successful !
  
<img width="2175" height="950" alt="image" src="https://github.com/user-attachments/assets/e7a93a85-8ac1-45ef-803e-82fdd6dd193e" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-VM serialization for DataUploads so newer uploads wait for older ones to finish, avoiding checkpoint conflicts.
  * Safer cleanup logic to avoid deleting backup trackers still referenced by active backups.

* **Bug Fixes**
  * Graceful reconstruction when a backup tracker is missing during archival, preventing failure.

* **Tests**
  * Large expansion of test coverage for sequencing, terminal-state detection, checkpoint lookup, archival, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->