### PR TITLE
first pass at konflux.dockerfile

### DIFF
--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,0 +1,25 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+COPY . .
+WORKDIR $APP_ROOT/app/
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+COPY cmd/main.go cmd/main.go
+COPY internal/ internal/
+COPY pkg/ pkg/
+ENV BUILDTAGS strictfipsruntime
+ENV GOEXPERIMENT strictfipsruntime
+RUN CGO_ENABLED=1 GOOS=linux go build -tags "$BUILDTAGS" -mod=mod -a -o manager cmd/main.go
+
+FROM registry.redhat.io/ubi9/ubi:latest
+COPY --from=builder $APP_ROOT/app/manager /manager
+
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]
+
+LABEL description="KubeVirt data mover controller"
+LABEL io.k8s.description="KubeVirt data mover controller"
+LABEL io.k8s.display-name="kubevirt-datamover-controller"
+LABEL io.openshift.tags="migration"
+LABEL summary="KubeVirt data mover controller"


### PR DESCRIPTION
```
podman build -f konflux.Dockerfile 
[1/2] STEP 1/12: FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
[1/2] STEP 2/12: COPY . .
--> b84ad7e06a25
[1/2] STEP 3/12: WORKDIR $APP_ROOT/app/
--> 75d8b4d0f02b
[1/2] STEP 4/12: COPY go.mod go.mod
--> aaa8beac1770
[1/2] STEP 5/12: COPY go.sum go.sum
--> 7c0cdfbe0910
[1/2] STEP 6/12: RUN go mod download
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: assessment: CGO_ENABLED=1
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: assessment: dynamic linking
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: skipping forced compliance due to broad exemption
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: EXEMPT: 1


Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: final command line arguments: "mod" "download" 

Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: invoking real go binary
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: Exited with: 0
--> f2194746e3b3
[1/2] STEP 7/12: COPY cmd/main.go cmd/main.go
--> 961ade91e608
[1/2] STEP 8/12: COPY internal/ internal/
--> 80e01b1e7e1e
[1/2] STEP 9/12: COPY pkg/ pkg/
--> 8a00f8659fce
[1/2] STEP 10/12: ENV BUILDTAGS strictfipsruntime
--> 400ab31785b2
[1/2] STEP 11/12: ENV GOEXPERIMENT strictfipsruntime
--> e7c2f0ab1116
[1/2] STEP 12/12: RUN CGO_ENABLED=1 GOOS=linux go build -tags "$BUILDTAGS" -mod=mod -a -o manager cmd/main.go
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: assessment: CGO_ENABLED=1
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: assessment: dynamic linking
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: skipping forced compliance due to broad exemption
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: EXEMPT: 1


Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: final command line arguments: "build" "-tags" "strictfipsruntime" "-mod=mod" "-a" "-o" "manager" "cmd/main.go" 

Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: invoking real go binary
Go compliance shim [1] [rhel-9-golang-1.25][openshift-golang-builder]: Exited with: 0
--> c81cb72ef725
[2/2] STEP 1/9: FROM registry.redhat.io/ubi9/ubi:latest
[2/2] STEP 2/9: COPY --from=builder $APP_ROOT/app/manager /manager
--> 5e83c57cd9c9
[2/2] STEP 3/9: USER 65532:65532
--> e93d4a41b8ea
[2/2] STEP 4/9: ENTRYPOINT ["/manager"]
--> 984c17e990e0
[2/2] STEP 5/9: LABEL description="KubeVirt data mover controller"
--> 55cad6997d1a
[2/2] STEP 6/9: LABEL io.k8s.description="KubeVirt data mover controller"
--> e637ab25503a
[2/2] STEP 7/9: LABEL io.k8s.display-name="kubevirt-datamover-controller"
--> b82fbee3dbbf
[2/2] STEP 8/9: LABEL io.openshift.tags="migration"
--> 56223791c328
[2/2] STEP 9/9: LABEL summary="KubeVirt data mover controller"
[2/2] COMMIT
--> 9d4ec6bfb542
9d4ec6bfb542b11d188cab234a2f9cc48c090b1afef68d01f5905829da0d5649

```
