### PR TITLE
fix(#14): default SkipQuiesce=true, opt-in application-consistent backup

### DIFF
--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -339,13 +339,12 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 		}
 
 		// Step 4: Create VirtualMachineBackup
-		// Default is crash-consistent (SkipQuiesce=true). Users opt in to
-		// application-consistent (quiesced) backup via AnnotationRequireQuiesce
-		// on the Velero Backup / DataUpload. See pkg/common constants for
-		// rationale. Fixes #14.
-		requireQuiesce := du.Annotations[common.AnnotationRequireQuiesce] == "true"
+		// Default is application-consistent (SkipQuiesce=false), matching
+		// KubeVirt's own default. Users opt out via AnnotationSkipQuiesce
+		// on the DataUpload (propagated from Backup or VM). Fixes #14.
+		skipQuiesce := du.Annotations[common.AnnotationSkipQuiesce] == "true"
 		var created bool
-		vmb, created, err = r.ensureVMBackup(ctx, logger, du, vmbt, pvc.Name, vmRef.Namespace, forceFullBackup, requireQuiesce)
+		vmb, created, err = r.ensureVMBackup(ctx, logger, du, vmbt, pvc.Name, vmRef.Namespace, forceFullBackup, skipQuiesce)
 		if err != nil {
 			// Check if the error is due to another VMB being in progress for the same VM.
 			// KubeVirt's admission webhook only allows one active (non-terminal) VMB per VM.
@@ -420,21 +419,22 @@ func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 	}
 
 	if doneCond != nil && doneCond.Status == corev1.ConditionTrue {
-		// When the user required an application-consistent (quiesced) backup
-		// via AnnotationRequireQuiesce, a freeze failure means the guarantee
-		// was not met even though KubeVirt reports the backup as Done=True.
-		// In that case we fail the DataUpload rather than silently completing
-		// as crash-consistent. Fixes #14.
+		// By default quiescing is enabled (SkipQuiesce=false), so a freeze
+		// failure means the application-consistent guarantee was not met even
+		// though KubeVirt reports the backup as Done=True. Fail the DataUpload
+		// so the user gets a clear signal. When AnnotationSkipQuiesce is set,
+		// the user explicitly opted out of quiescing, so freeze warnings are
+		// moot and we allow the backup to proceed. Fixes #14.
+		//
 		// In KubeVirt v1.8.0 the freeze-failure text is propagated via
 		// virt-launcher's BackupMsg → resolveCompletion → SyncInfo.reason →
 		// newDoneCondition, which only populates the condition's Reason field.
-		// We also check Message defensively in case a future KubeVirt release
-		// routes the same warning through the Message field instead.
-		requireQuiesce := du.Annotations[common.AnnotationRequireQuiesce] == "true"
+		// We also check Message defensively for forward compatibility.
+		skipQuiesce := du.Annotations[common.AnnotationSkipQuiesce] == "true"
 		freezeFailed := strings.Contains(doneCond.Reason, common.FreezeFailureMarker) ||
 			strings.Contains(doneCond.Message, common.FreezeFailureMarker)
-		if requireQuiesce && freezeFailed {
-			logger.Error(nil, "VirtualMachineBackup completed but guest filesystem freeze failed and require-quiesce was requested",
+		if !skipQuiesce && freezeFailed {
+			logger.Error(nil, "VirtualMachineBackup completed but guest filesystem freeze failed",
 				"vmb", vmb.Name,
 				"reason", doneCond.Reason,
 				"message", doneCond.Message)
@@ -1222,14 +1222,15 @@ func (r *KubeVirtDataUploadReconciler) lookupLatestVMBTFromBSL(ctx context.Conte
 // Returns the VMB, whether it was created (vs already existed), and any error.
 // When forceFullBackup is true, the VMB is created with ForceFullBackup=true in its spec,
 // which tells KubeVirt to perform a full backup regardless of any existing checkpoint.
-// When requireQuiesce is true, the VMB is created with SkipQuiesce=false (the KubeVirt
-// default) so the QEMU guest agent is asked to freeze the filesystem, producing an
-// application-consistent backup. Otherwise SkipQuiesce=true is set and the backup is
-// crash-consistent. See common.AnnotationRequireQuiesce for rationale.
+// When skipQuiesce is true, the VMB is created with SkipQuiesce=true so the
+// QEMU guest agent is not asked to freeze the filesystem, producing a
+// crash-consistent backup. Otherwise SkipQuiesce=false (the KubeVirt default)
+// is used, requesting an application-consistent backup.
+// See common.AnnotationSkipQuiesce for rationale.
 // Note: We don't set an owner reference because VMB is in VM namespace
 // while DataUpload is in OADP namespace (cross-namespace owner refs not allowed).
 // VMB and VMBT are archived to S3 and deleted by the datamover pod after upload.
-func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, vmbt *kubevirtbackupv1alpha1.VirtualMachineBackupTracker, pvcName, namespace string, forceFullBackup, requireQuiesce bool) (*kubevirtbackupv1alpha1.VirtualMachineBackup, bool, error) {
+func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, vmbt *kubevirtbackupv1alpha1.VirtualMachineBackupTracker, pvcName, namespace string, forceFullBackup, skipQuiesce bool) (*kubevirtbackupv1alpha1.VirtualMachineBackup, bool, error) {
 	// Find existing VMB for this DataUpload
 	existingVMB, err := r.findVMBForDataUpload(ctx, du, namespace)
 	if err != nil {
@@ -1261,7 +1262,7 @@ func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logge
 			},
 			PvcName:         &pvcName,
 			ForceFullBackup: forceFullBackup,
-			SkipQuiesce:     !requireQuiesce,
+			SkipQuiesce:     skipQuiesce,
 		},
 	}
 
@@ -1271,8 +1272,8 @@ func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logge
 	if forceFullBackup {
 		logger.Info("Creating VirtualMachineBackup with ForceFullBackup=true", "vmb", vmb.Name)
 	}
-	if requireQuiesce {
-		logger.Info("Creating VirtualMachineBackup with SkipQuiesce=false (application-consistent)", "vmb", vmb.Name)
+	if skipQuiesce {
+		logger.Info("Creating VirtualMachineBackup with SkipQuiesce=true (crash-consistent)", "vmb", vmb.Name)
 	}
 
 	logger.Info("Created VirtualMachineBackup", "generateName", vmb.GenerateName, "namespace", namespace, "tracker", vmbt.Name)

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -339,8 +339,13 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 		}
 
 		// Step 4: Create VirtualMachineBackup
+		// Default is crash-consistent (SkipQuiesce=true). Users opt in to
+		// application-consistent (quiesced) backup via AnnotationRequireQuiesce
+		// on the Velero Backup / DataUpload. See pkg/common constants for
+		// rationale. Fixes #14.
+		requireQuiesce := du.Annotations[common.AnnotationRequireQuiesce] == "true"
 		var created bool
-		vmb, created, err = r.ensureVMBackup(ctx, logger, du, vmbt, pvc.Name, vmRef.Namespace, forceFullBackup)
+		vmb, created, err = r.ensureVMBackup(ctx, logger, du, vmbt, pvc.Name, vmRef.Namespace, forceFullBackup, requireQuiesce)
 		if err != nil {
 			// Check if the error is due to another VMB being in progress for the same VM.
 			// KubeVirt's admission webhook only allows one active (non-terminal) VMB per VM.
@@ -415,6 +420,23 @@ func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 	}
 
 	if doneCond != nil && doneCond.Status == corev1.ConditionTrue {
+		// When the user required an application-consistent (quiesced) backup
+		// via AnnotationRequireQuiesce, a freeze failure means the guarantee
+		// was not met even though KubeVirt reports the backup as Done=True.
+		// In that case we fail the DataUpload rather than silently completing
+		// as crash-consistent. Fixes #14.
+		if du.Annotations[common.AnnotationRequireQuiesce] == "true" &&
+			strings.Contains(doneCond.Reason, common.FreezeFailureMarker) {
+			logger.Error(nil, "VirtualMachineBackup completed but guest filesystem freeze failed and require-quiesce was requested",
+				"vmb", vmb.Name,
+				"reason", doneCond.Reason)
+			if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
+				fmt.Sprintf("Application-consistent backup failed: %s", doneCond.Reason)); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+
 		logger.Info("VirtualMachineBackup completed",
 			"vmb", vmb.Name,
 			"type", vmb.Status.Type,
@@ -1191,10 +1213,14 @@ func (r *KubeVirtDataUploadReconciler) lookupLatestVMBTFromBSL(ctx context.Conte
 // Returns the VMB, whether it was created (vs already existed), and any error.
 // When forceFullBackup is true, the VMB is created with ForceFullBackup=true in its spec,
 // which tells KubeVirt to perform a full backup regardless of any existing checkpoint.
+// When requireQuiesce is true, the VMB is created with SkipQuiesce=false (the KubeVirt
+// default) so the QEMU guest agent is asked to freeze the filesystem, producing an
+// application-consistent backup. Otherwise SkipQuiesce=true is set and the backup is
+// crash-consistent. See common.AnnotationRequireQuiesce for rationale.
 // Note: We don't set an owner reference because VMB is in VM namespace
 // while DataUpload is in OADP namespace (cross-namespace owner refs not allowed).
 // VMB and VMBT are archived to S3 and deleted by the datamover pod after upload.
-func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, vmbt *kubevirtbackupv1alpha1.VirtualMachineBackupTracker, pvcName, namespace string, forceFullBackup bool) (*kubevirtbackupv1alpha1.VirtualMachineBackup, bool, error) {
+func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, vmbt *kubevirtbackupv1alpha1.VirtualMachineBackupTracker, pvcName, namespace string, forceFullBackup, requireQuiesce bool) (*kubevirtbackupv1alpha1.VirtualMachineBackup, bool, error) {
 	// Find existing VMB for this DataUpload
 	existingVMB, err := r.findVMBForDataUpload(ctx, du, namespace)
 	if err != nil {
@@ -1226,6 +1252,7 @@ func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logge
 			},
 			PvcName:         &pvcName,
 			ForceFullBackup: forceFullBackup,
+			SkipQuiesce:     !requireQuiesce,
 		},
 	}
 
@@ -1234,6 +1261,9 @@ func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logge
 	}
 	if forceFullBackup {
 		logger.Info("Creating VirtualMachineBackup with ForceFullBackup=true", "vmb", vmb.Name)
+	}
+	if requireQuiesce {
+		logger.Info("Creating VirtualMachineBackup with SkipQuiesce=false (application-consistent)", "vmb", vmb.Name)
 	}
 
 	logger.Info("Created VirtualMachineBackup", "generateName", vmb.GenerateName, "namespace", namespace, "tracker", vmbt.Name)

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -425,13 +425,22 @@ func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 		// was not met even though KubeVirt reports the backup as Done=True.
 		// In that case we fail the DataUpload rather than silently completing
 		// as crash-consistent. Fixes #14.
-		if du.Annotations[common.AnnotationRequireQuiesce] == "true" &&
-			strings.Contains(doneCond.Reason, common.FreezeFailureMarker) {
+		// In KubeVirt v1.8.0 the freeze-failure text is propagated via
+		// virt-launcher's BackupMsg → resolveCompletion → SyncInfo.reason →
+		// newDoneCondition, which only populates the condition's Reason field.
+		// We also check Message defensively in case a future KubeVirt release
+		// routes the same warning through the Message field instead.
+		requireQuiesce := du.Annotations[common.AnnotationRequireQuiesce] == "true"
+		freezeFailed := strings.Contains(doneCond.Reason, common.FreezeFailureMarker) ||
+			strings.Contains(doneCond.Message, common.FreezeFailureMarker)
+		if requireQuiesce && freezeFailed {
 			logger.Error(nil, "VirtualMachineBackup completed but guest filesystem freeze failed and require-quiesce was requested",
 				"vmb", vmb.Name,
-				"reason", doneCond.Reason)
+				"reason", doneCond.Reason,
+				"message", doneCond.Message)
+			detail := strings.TrimSpace(doneCond.Reason + " " + doneCond.Message)
 			if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
-				fmt.Sprintf("Application-consistent backup failed: %s", doneCond.Reason)); err != nil {
+				fmt.Sprintf("Application-consistent backup failed: %s", detail)); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -641,11 +641,12 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	tests := []struct {
-		name          string
-		vmbConditions []kubevirtbackupv1alpha1.Condition
-		expectedPhase velerov2alpha1.DataUploadPhase
-		expectRequeue bool
-		skipVMBT      bool // when true, do not create the VMBT (simulates deleted VMBT)
+		name           string
+		vmbConditions  []kubevirtbackupv1alpha1.Condition
+		expectedPhase  velerov2alpha1.DataUploadPhase
+		expectRequeue  bool
+		skipVMBT       bool // when true, do not create the VMBT (simulates deleted VMBT)
+		requireQuiesce bool // when true, set the require-quiesce annotation on the DU
 	}{
 		{
 			name: "VMB Done True transitions to Prepared",
@@ -781,6 +782,67 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			expectedPhase: velerov2alpha1.DataUploadPhaseAccepted, // unchanged
 			expectRequeue: true,
 		},
+		{
+			// Freeze failure warning is harmless by default — KubeVirt completed
+			// the backup as crash-consistent and the user did not require
+			// application-consistency. See #14.
+			name: "VMB Done True with freeze-failure warning transitions to Prepared when require-quiesce is not set",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding: QEMU guest agent is not connected')",
+				},
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionDone,
+					Status: corev1.ConditionTrue,
+					Reason: "Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding: QEMU guest agent is not connected')",
+				},
+			},
+			expectedPhase: velerov2alpha1.DataUploadPhasePrepared,
+			expectRequeue: true,
+		},
+		{
+			// User explicitly required application-consistency but the freeze
+			// failed — the backup is crash-consistent, which violates the
+			// user's request, so the DataUpload must fail. See #14.
+			name: "VMB Done True with freeze-failure transitions to Failed when require-quiesce is set",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding: QEMU guest agent is not connected')",
+				},
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionDone,
+					Status: corev1.ConditionTrue,
+					Reason: "Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding: QEMU guest agent is not connected')",
+				},
+			},
+			expectedPhase:  velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue:  false,
+			requireQuiesce: true,
+		},
+		{
+			// Clean completion + require-quiesce: no freeze failure in the
+			// Reason, so the DataUpload should still succeed.
+			name: "VMB Done True clean transitions to Prepared when require-quiesce is set",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "Completed VirtualMachineBackup",
+				},
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionDone,
+					Status: corev1.ConditionTrue,
+					Reason: "Completed VirtualMachineBackup",
+				},
+			},
+			expectedPhase:  velerov2alpha1.DataUploadPhasePrepared,
+			expectRequeue:  true,
+			requireQuiesce: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -790,15 +852,19 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			duName := "test-du"
 
 			// Create DataUpload
+			duAnnotations := map[string]string{
+				common.AnnotationVMName:      vmName,
+				common.AnnotationVMNamespace: vmNamespace,
+			}
+			if tt.requireQuiesce {
+				duAnnotations[common.AnnotationRequireQuiesce] = "true"
+			}
 			du := &velerov2alpha1.DataUpload{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      duName,
-					Namespace: vmNamespace,
-					UID:       types.UID("test-uid"),
-					Annotations: map[string]string{
-						common.AnnotationVMName:      vmName,
-						common.AnnotationVMNamespace: vmNamespace,
-					},
+					Name:        duName,
+					Namespace:   vmNamespace,
+					UID:         types.UID("test-uid"),
+					Annotations: duAnnotations,
 				},
 				Spec: velerov2alpha1.DataUploadSpec{
 					DataMover:       common.DataMoverKubeVirt,
@@ -5003,6 +5069,189 @@ func TestHandleAccepted_NoForceFullBackupByDefault(t *testing.T) {
 
 	if createdVMB.Spec.ForceFullBackup {
 		t.Error("expected VMB.Spec.ForceFullBackup to be false when annotation is not set")
+	}
+}
+
+// TestHandleAccepted_SkipQuiesceByDefault verifies that, absent the
+// require-quiesce annotation, the VMB is created with SkipQuiesce=true.
+// This matches the crash-consistent default agreed in #14 and avoids noisy
+// freeze warnings on VMs without the QEMU guest agent installed.
+func TestHandleAccepted_SkipQuiesceByDefault(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	vmName := "test-vm"
+	vmNamespace := "test-ns"
+	duName := "test-du-default-quiesce"
+
+	du := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      duName,
+			Namespace: vmNamespace,
+			UID:       types.UID("test-uid"),
+			Annotations: map[string]string{
+				common.AnnotationVMName:       vmName,
+				common.AnnotationVMNamespace:  vmNamespace,
+				common.AnnotationBSLValidated: "true",
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover:       common.DataMoverKubeVirt,
+			SourceNamespace: vmNamespace,
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseAccepted,
+		},
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-backup-" + duName,
+			Namespace: vmNamespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	vmbt := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vmbt-" + vmName,
+			Namespace: vmNamespace,
+		},
+		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
+			Source: corev1.TypedLocalObjectReference{
+				APIGroup: strPtr("kubevirt.io"),
+				Kind:     "VirtualMachine",
+				Name:     vmName,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du, pvc, vmbt).
+		Build()
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		OADPNamespace: vmNamespace,
+	}
+
+	if _, err := r.handleAccepted(context.Background(), logr.Discard(), du); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	vmbList := &kubevirtbackupv1alpha1.VirtualMachineBackupList{}
+	if err := fakeClient.List(context.Background(), vmbList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		t.Fatalf("failed to list created VMBs: %v", err)
+	}
+	if len(vmbList.Items) != 1 {
+		t.Fatalf("expected 1 VMB, got %d", len(vmbList.Items))
+	}
+	if !vmbList.Items[0].Spec.SkipQuiesce {
+		t.Error("expected VMB.Spec.SkipQuiesce=true by default (crash-consistent)")
+	}
+}
+
+// TestHandleAccepted_RequireQuiesceAnnotation verifies that when the user
+// sets the require-quiesce annotation on the DataUpload, the VMB is created
+// with SkipQuiesce=false so KubeVirt attempts the guest-agent-mediated
+// filesystem freeze for an application-consistent backup.
+func TestHandleAccepted_RequireQuiesceAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	vmName := "test-vm"
+	vmNamespace := "test-ns"
+	duName := "test-du-require-quiesce"
+
+	du := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      duName,
+			Namespace: vmNamespace,
+			UID:       types.UID("test-uid"),
+			Annotations: map[string]string{
+				common.AnnotationVMName:         vmName,
+				common.AnnotationVMNamespace:    vmNamespace,
+				common.AnnotationBSLValidated:   "true",
+				common.AnnotationRequireQuiesce: "true",
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover:       common.DataMoverKubeVirt,
+			SourceNamespace: vmNamespace,
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseAccepted,
+		},
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubevirt-backup-" + duName,
+			Namespace: vmNamespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	vmbt := &kubevirtbackupv1alpha1.VirtualMachineBackupTracker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vmbt-" + vmName,
+			Namespace: vmNamespace,
+		},
+		Spec: kubevirtbackupv1alpha1.VirtualMachineBackupTrackerSpec{
+			Source: corev1.TypedLocalObjectReference{
+				APIGroup: strPtr("kubevirt.io"),
+				Kind:     "VirtualMachine",
+				Name:     vmName,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du, pvc, vmbt).
+		Build()
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Log:           logr.Discard(),
+		OADPNamespace: vmNamespace,
+	}
+
+	if _, err := r.handleAccepted(context.Background(), logr.Discard(), du); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	vmbList := &kubevirtbackupv1alpha1.VirtualMachineBackupList{}
+	if err := fakeClient.List(context.Background(), vmbList, client.InNamespace(vmNamespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
+		t.Fatalf("failed to list created VMBs: %v", err)
+	}
+	if len(vmbList.Items) != 1 {
+		t.Fatalf("expected 1 VMB, got %d", len(vmbList.Items))
+	}
+	if vmbList.Items[0].Spec.SkipQuiesce {
+		t.Error("expected VMB.Spec.SkipQuiesce=false when require-quiesce annotation is set")
 	}
 }
 

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -824,6 +824,28 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			requireQuiesce: true,
 		},
 		{
+			// Defensive: if a future KubeVirt release routes the freeze-
+			// failure warning through the Message field instead of Reason,
+			// we should still detect it when require-quiesce is set.
+			name: "VMB Done True with freeze-failure in Message transitions to Failed when require-quiesce is set",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "Completed VirtualMachineBackup",
+				},
+				{
+					Type:    kubevirtbackupv1alpha1.ConditionDone,
+					Status:  corev1.ConditionTrue,
+					Reason:  "CompletedWithWarning",
+					Message: "Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding')",
+				},
+			},
+			expectedPhase:  velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue:  false,
+			requireQuiesce: true,
+		},
+		{
 			// Clean completion + require-quiesce: no freeze failure in the
 			// Reason, so the DataUpload should still succeed.
 			name: "VMB Done True clean transitions to Prepared when require-quiesce is set",

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -641,12 +641,12 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	tests := []struct {
-		name           string
-		vmbConditions  []kubevirtbackupv1alpha1.Condition
-		expectedPhase  velerov2alpha1.DataUploadPhase
-		expectRequeue  bool
-		skipVMBT       bool // when true, do not create the VMBT (simulates deleted VMBT)
-		skipQuiesce bool // when true, set the skip-quiesce annotation on the DU
+		name          string
+		vmbConditions []kubevirtbackupv1alpha1.Condition
+		expectedPhase velerov2alpha1.DataUploadPhase
+		expectRequeue bool
+		skipVMBT      bool // when true, do not create the VMBT (simulates deleted VMBT)
+		skipQuiesce   bool // when true, set the skip-quiesce annotation on the DU
 	}{
 		{
 			name: "VMB Done True transitions to Prepared",

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -646,7 +646,7 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 		expectedPhase  velerov2alpha1.DataUploadPhase
 		expectRequeue  bool
 		skipVMBT       bool // when true, do not create the VMBT (simulates deleted VMBT)
-		requireQuiesce bool // when true, set the require-quiesce annotation on the DU
+		skipQuiesce bool // when true, set the skip-quiesce annotation on the DU
 	}{
 		{
 			name: "VMB Done True transitions to Prepared",
@@ -783,10 +783,29 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			expectRequeue: true,
 		},
 		{
-			// Freeze failure warning is harmless by default — KubeVirt completed
-			// the backup as crash-consistent and the user did not require
-			// application-consistency. See #14.
-			name: "VMB Done True with freeze-failure warning transitions to Prepared when require-quiesce is not set",
+			// By default quiescing is enabled, so a freeze failure means the
+			// application-consistent guarantee was not met → DataUpload must
+			// fail. See #14.
+			name: "VMB Done True with freeze-failure transitions to Failed by default",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding: QEMU guest agent is not connected')",
+				},
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionDone,
+					Status: corev1.ConditionTrue,
+					Reason: "Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding: QEMU guest agent is not connected')",
+				},
+			},
+			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue: false,
+		},
+		{
+			// When skip-quiesce is set, the user opted out of quiescing, so
+			// freeze warnings are harmless — allow the backup to proceed.
+			name: "VMB Done True with freeze-failure transitions to Prepared when skip-quiesce is set",
 			vmbConditions: []kubevirtbackupv1alpha1.Condition{
 				{
 					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
@@ -801,33 +820,13 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			},
 			expectedPhase: velerov2alpha1.DataUploadPhasePrepared,
 			expectRequeue: true,
-		},
-		{
-			// User explicitly required application-consistency but the freeze
-			// failed — the backup is crash-consistent, which violates the
-			// user's request, so the DataUpload must fail. See #14.
-			name: "VMB Done True with freeze-failure transitions to Failed when require-quiesce is set",
-			vmbConditions: []kubevirtbackupv1alpha1.Condition{
-				{
-					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
-					Status: corev1.ConditionFalse,
-					Reason: "Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding: QEMU guest agent is not connected')",
-				},
-				{
-					Type:   kubevirtbackupv1alpha1.ConditionDone,
-					Status: corev1.ConditionTrue,
-					Reason: "Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding: QEMU guest agent is not connected')",
-				},
-			},
-			expectedPhase:  velerov2alpha1.DataUploadPhaseFailed,
-			expectRequeue:  false,
-			requireQuiesce: true,
+			skipQuiesce:   true,
 		},
 		{
 			// Defensive: if a future KubeVirt release routes the freeze-
 			// failure warning through the Message field instead of Reason,
-			// we should still detect it when require-quiesce is set.
-			name: "VMB Done True with freeze-failure in Message transitions to Failed when require-quiesce is set",
+			// we should still detect it (default quiesce ON → fail).
+			name: "VMB Done True with freeze-failure in Message transitions to Failed by default",
 			vmbConditions: []kubevirtbackupv1alpha1.Condition{
 				{
 					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
@@ -841,14 +840,13 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 					Message: "Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding')",
 				},
 			},
-			expectedPhase:  velerov2alpha1.DataUploadPhaseFailed,
-			expectRequeue:  false,
-			requireQuiesce: true,
+			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue: false,
 		},
 		{
-			// Clean completion + require-quiesce: no freeze failure in the
-			// Reason, so the DataUpload should still succeed.
-			name: "VMB Done True clean transitions to Prepared when require-quiesce is set",
+			// Clean completion (no freeze failure) should succeed regardless
+			// of quiesce setting.
+			name: "VMB Done True clean transitions to Prepared",
 			vmbConditions: []kubevirtbackupv1alpha1.Condition{
 				{
 					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
@@ -861,9 +859,8 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 					Reason: "Completed VirtualMachineBackup",
 				},
 			},
-			expectedPhase:  velerov2alpha1.DataUploadPhasePrepared,
-			expectRequeue:  true,
-			requireQuiesce: true,
+			expectedPhase: velerov2alpha1.DataUploadPhasePrepared,
+			expectRequeue: true,
 		},
 	}
 
@@ -878,8 +875,8 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 				common.AnnotationVMName:      vmName,
 				common.AnnotationVMNamespace: vmNamespace,
 			}
-			if tt.requireQuiesce {
-				duAnnotations[common.AnnotationRequireQuiesce] = "true"
+			if tt.skipQuiesce {
+				duAnnotations[common.AnnotationSkipQuiesce] = "true"
 			}
 			du := &velerov2alpha1.DataUpload{
 				ObjectMeta: metav1.ObjectMeta{
@@ -5094,11 +5091,11 @@ func TestHandleAccepted_NoForceFullBackupByDefault(t *testing.T) {
 	}
 }
 
-// TestHandleAccepted_SkipQuiesceByDefault verifies that, absent the
-// require-quiesce annotation, the VMB is created with SkipQuiesce=true.
-// This matches the crash-consistent default agreed in #14 and avoids noisy
-// freeze warnings on VMs without the QEMU guest agent installed.
-func TestHandleAccepted_SkipQuiesceByDefault(t *testing.T) {
+// TestHandleAccepted_QuiesceByDefault verifies that, absent the
+// skip-quiesce annotation, the VMB is created with SkipQuiesce=false.
+// This matches KubeVirt's own default for VirtualMachineBackup.Spec.SkipQuiesce
+// and produces application-consistent backups. See #14.
+func TestHandleAccepted_QuiesceByDefault(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = velerov2alpha1.AddToScheme(scheme)
 	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
@@ -5180,16 +5177,16 @@ func TestHandleAccepted_SkipQuiesceByDefault(t *testing.T) {
 	if len(vmbList.Items) != 1 {
 		t.Fatalf("expected 1 VMB, got %d", len(vmbList.Items))
 	}
-	if !vmbList.Items[0].Spec.SkipQuiesce {
-		t.Error("expected VMB.Spec.SkipQuiesce=true by default (crash-consistent)")
+	if vmbList.Items[0].Spec.SkipQuiesce {
+		t.Error("expected VMB.Spec.SkipQuiesce=false by default (application-consistent)")
 	}
 }
 
-// TestHandleAccepted_RequireQuiesceAnnotation verifies that when the user
-// sets the require-quiesce annotation on the DataUpload, the VMB is created
-// with SkipQuiesce=false so KubeVirt attempts the guest-agent-mediated
-// filesystem freeze for an application-consistent backup.
-func TestHandleAccepted_RequireQuiesceAnnotation(t *testing.T) {
+// TestHandleAccepted_SkipQuiesceAnnotation verifies that when the user
+// sets the skip-quiesce annotation on the DataUpload, the VMB is created
+// with SkipQuiesce=true so KubeVirt skips the guest-agent-mediated
+// filesystem freeze and produces a crash-consistent backup.
+func TestHandleAccepted_SkipQuiesceAnnotation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = velerov2alpha1.AddToScheme(scheme)
 	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
@@ -5197,7 +5194,7 @@ func TestHandleAccepted_RequireQuiesceAnnotation(t *testing.T) {
 
 	vmName := "test-vm"
 	vmNamespace := "test-ns"
-	duName := "test-du-require-quiesce"
+	duName := "test-du-skip-quiesce"
 
 	du := &velerov2alpha1.DataUpload{
 		ObjectMeta: metav1.ObjectMeta{
@@ -5205,10 +5202,10 @@ func TestHandleAccepted_RequireQuiesceAnnotation(t *testing.T) {
 			Namespace: vmNamespace,
 			UID:       types.UID("test-uid"),
 			Annotations: map[string]string{
-				common.AnnotationVMName:         vmName,
-				common.AnnotationVMNamespace:    vmNamespace,
-				common.AnnotationBSLValidated:   "true",
-				common.AnnotationRequireQuiesce: "true",
+				common.AnnotationVMName:       vmName,
+				common.AnnotationVMNamespace:  vmNamespace,
+				common.AnnotationBSLValidated: "true",
+				common.AnnotationSkipQuiesce:  "true",
 			},
 		},
 		Spec: velerov2alpha1.DataUploadSpec{
@@ -5272,8 +5269,8 @@ func TestHandleAccepted_RequireQuiesceAnnotation(t *testing.T) {
 	if len(vmbList.Items) != 1 {
 		t.Fatalf("expected 1 VMB, got %d", len(vmbList.Items))
 	}
-	if vmbList.Items[0].Spec.SkipQuiesce {
-		t.Error("expected VMB.Spec.SkipQuiesce=false when require-quiesce annotation is set")
+	if !vmbList.Items[0].Spec.SkipQuiesce {
+		t.Error("expected VMB.Spec.SkipQuiesce=true when skip-quiesce annotation is set")
 	}
 }
 

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -47,6 +47,42 @@ const (
 	// AnnotationDataUploadName is the annotation key for the DataUpload name.
 	// Used on VMB, VMBT, and PVC resources to track ownership.
 	AnnotationDataUploadName = "velero.io/dataupload-name"
+
+	// AnnotationRequireQuiesce, when set to "true" on a DataUpload, requires
+	// that the VirtualMachineBackup produce an application-consistent
+	// (quiesced) backup via the QEMU guest agent. If the guest filesystem
+	// freeze fails, the DataUpload is marked Failed rather than silently
+	// completing as crash-consistent.
+	//
+	// Default behavior (annotation absent or not "true") is crash-consistent:
+	// the VMB is created with SkipQuiesce=true so KubeVirt does not attempt
+	// the guest-agent-dependent freeze, avoiding noisy warnings on VMs
+	// without the guest agent installed. This matches user expectations for
+	// mixed fleets and fixes #14.
+	//
+	// This annotation is sourced from the Velero Backup CR
+	// (same key, oadp.openshift.io/require-quiesce) and propagated onto
+	// the DataUpload by the OADP plugin.
+	AnnotationRequireQuiesce = "oadp.openshift.io/require-quiesce"
+)
+
+// VirtualMachineBackup status matching
+const (
+	// FreezeFailureMarker is the substring used to detect a failed guest
+	// filesystem freeze in a VirtualMachineBackup's Done condition Reason.
+	//
+	// When the QEMU guest agent is not connected but SkipQuiesce=false was
+	// requested, KubeVirt completes the backup (Done=True) but reports a
+	// warning in the Done condition's Reason of the form:
+	//
+	//     Completed VirtualMachineBackup, warning: Failed freezing guest
+	//     filesystem: virError(...Guest agent is not responding...)
+	//
+	// The backup data is still written, but it is crash-consistent rather
+	// than application-consistent. The controller checks for this marker
+	// only when AnnotationRequireQuiesce is set; otherwise the warning is
+	// harmless and the DataUpload is allowed to proceed.
+	FreezeFailureMarker = "Failed freezing guest filesystem"
 )
 
 // Label keys for resources created by the controller.

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -48,22 +48,22 @@ const (
 	// Used on VMB, VMBT, and PVC resources to track ownership.
 	AnnotationDataUploadName = "velero.io/dataupload-name"
 
-	// AnnotationRequireQuiesce, when set to "true" on a DataUpload, requires
-	// that the VirtualMachineBackup produce an application-consistent
-	// (quiesced) backup via the QEMU guest agent. If the guest filesystem
-	// freeze fails, the DataUpload is marked Failed rather than silently
-	// completing as crash-consistent.
+	// AnnotationSkipQuiesce, when set to "true" on a DataUpload, skips
+	// guest filesystem quiescing and produces a crash-consistent backup
+	// instead of an application-consistent one. This is useful for VMs
+	// without the QEMU guest agent installed or where quiescing is known
+	// to fail.
 	//
-	// Default behavior (annotation absent or not "true") is crash-consistent:
-	// the VMB is created with SkipQuiesce=true so KubeVirt does not attempt
-	// the guest-agent-dependent freeze, avoiding noisy warnings on VMs
-	// without the guest agent installed. This matches user expectations for
-	// mixed fleets and fixes #14.
+	// Default behavior (annotation absent or not "true") is
+	// application-consistent: the VMB is created with SkipQuiesce=false
+	// so KubeVirt attempts the guest-agent-dependent freeze. This follows
+	// KubeVirt's own default for VirtualMachineBackup.Spec.SkipQuiesce.
+	// If the freeze fails, the DataUpload is marked Failed so the user
+	// gets a clear signal rather than a silent fallback to crash-consistent.
 	//
-	// This annotation is sourced from the Velero Backup CR
-	// (same key, oadp.openshift.io/require-quiesce) and propagated onto
-	// the DataUpload by the OADP plugin.
-	AnnotationRequireQuiesce = "oadp.openshift.io/require-quiesce"
+	// This annotation is propagated onto the DataUpload by the OADP plugin
+	// from the Velero Backup CR or the source VM. Fixes #14.
+	AnnotationSkipQuiesce = "kubevirt-datamover.io/skip-quiesce"
 )
 
 // VirtualMachineBackup status matching
@@ -71,17 +71,17 @@ const (
 	// FreezeFailureMarker is the substring used to detect a failed guest
 	// filesystem freeze in a VirtualMachineBackup's Done condition Reason.
 	//
-	// When the QEMU guest agent is not connected but SkipQuiesce=false was
-	// requested, KubeVirt completes the backup (Done=True) but reports a
-	// warning in the Done condition's Reason of the form:
+	// When the QEMU guest agent is not connected and SkipQuiesce=false
+	// (the default), KubeVirt completes the backup (Done=True) but reports
+	// a warning in the Done condition's Reason of the form:
 	//
 	//     Completed VirtualMachineBackup, warning: Failed freezing guest
 	//     filesystem: virError(...Guest agent is not responding...)
 	//
 	// The backup data is still written, but it is crash-consistent rather
-	// than application-consistent. The controller checks for this marker
-	// only when AnnotationRequireQuiesce is set; otherwise the warning is
-	// harmless and the DataUpload is allowed to proceed.
+	// than application-consistent. The controller fails the DataUpload
+	// when this marker is detected (unless AnnotationSkipQuiesce is set,
+	// in which case quiescing was not requested and the warning is moot).
 	FreezeFailureMarker = "Failed freezing guest filesystem"
 )
 


### PR DESCRIPTION
## Summary

Default `VirtualMachineBackup.Spec.SkipQuiesce` to `true` (crash-consistent) and let users opt in to application-consistent backups via the `oadp.openshift.io/require-quiesce` annotation on the DataUpload. When that annotation is set and the guest filesystem freeze fails, the DataUpload is failed rather than silently completing as crash-consistent.

This implements the "Agreed Implementation" section of #14 and also closes #17 (which asks the same question in more general terms).

## Rationale

On VMs without the QEMU guest agent installed, KubeVirt's `VirtualMachineBackup` currently reports `Done=True` but with a warning embedded in the condition's `Reason`:

> `Completed VirtualMachineBackup, warning: Failed freezing guest filesystem: virError(Code=86, Domain=10, Message='Guest agent is not responding: QEMU guest agent is not connected')`

The backup data is written and is crash-consistent, but the warning is noisy and confusing on mixed fleets where no agent is expected. Defaulting `SkipQuiesce=true` skips the freeze attempt entirely and matches the "sensible default for VMs without the guest agent" expectation from #14.

Users who need **application-consistent** backups can opt in with the annotation; if the freeze then fails, the DataUpload is marked `Failed` so the user gets a clear signal rather than an invalid guarantee.

## Changes

- **`pkg/common/constants.go`**
  - `AnnotationRequireQuiesce = "oadp.openshift.io/require-quiesce"` with rationale doc.
  - `FreezeFailureMarker = "Failed freezing guest filesystem"` with rationale doc.
- **`internal/controller/kubevirt_dataupload_controller.go`**
  - `handleAccepted` reads the annotation and threads `requireQuiesce` into `ensureVMBackup`.
  - `ensureVMBackup` gains a `requireQuiesce` parameter and sets `SkipQuiesce: !requireQuiesce` on the VMB spec.
  - `evaluateVMBackupStatus` checks `Done=True` conditions for the freeze-failure marker when `require-quiesce` is set, and fails the DataUpload with an "Application-consistent backup failed" message. When not set, the warning is ignored and the DataUpload transitions to `Prepared` as before.
- **Tests**
  - `TestHandleAccepted_SkipQuiesceByDefault` — no annotation → `SkipQuiesce=true`.
  - `TestHandleAccepted_RequireQuiesceAnnotation` — annotation set → `SkipQuiesce=false`.
  - Three new rows in `TestHandleAccepted_VMBStatusDetection`:
    - Freeze-failure warning + `require-quiesce` absent → `Prepared` (warning is harmless).
    - Freeze-failure warning + `require-quiesce` set → `Failed`.
    - Clean completion + `require-quiesce` set → `Prepared`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] `go test ./internal/controller/ -run "TestHandleAccepted_SkipQuiesceByDefault|TestHandleAccepted_RequireQuiesceAnnotation|TestHandleAccepted_VMBStatusDetection" -v`
  - 12 subtests under `VMBStatusDetection` (9 pre-existing + 3 new)
  - 2 new standalone tests
  - All pass
- [ ] e2e in CI (requires maintainer)

## Notes

- `make lint` in this repo currently fails with `the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.8)` — this is a pre-existing tooling issue unrelated to this PR. `go vet` and `gofmt` are clean.
- The annotation key `oadp.openshift.io/require-quiesce` is used verbatim from the agreed design in #14; it lives in the `oadp.openshift.io/` namespace rather than `kubevirt-datamover.io/` because the Velero Backup CR (which the OADP plugin propagates from) is OADP-facing. Happy to rename if you'd prefer the controller-native prefix.
- Closes #14 and #17.

Some context: I originally attempted a plugin-only CBT backup integration in [kubevirt/kubevirt-velero-plugin#412](https://github.com/kubevirt/kubevirt-velero-plugin/pull/412), was pointed at the OADP datamover design, and closed that PR to contribute here instead. Starting with this small focused change to build familiarity with the codebase; happy to tackle other open issues (#34/#42 force-full interval is on my list) if this lands cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New opt-in annotation to request quiesced (application-consistent) backups; backups remain crash-consistent by default.
  * Controller emits info when quiescing is requested.

* **Bug Fixes**
  * Backup runs that report freeze (guest filesystem) failures are now treated as failures when application-consistency is required.

* **Tests**
  * Added tests covering quiesce annotation behavior and freeze-failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->