### PR TITLE
Issue 46: Add pvcSizes to per-VM index file

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -109,7 +109,7 @@ func main() {
 		"Maximum number of concurrent reconciles for the KubeVirt DataUpload controller")
 	flag.StringVar(&datamoverImage, "datamover-image", common.DefaultDatamoverImage,
 		"Image to use for datamover pods")
-	flag.StringVar(&datamoverImagePullPolicy, "datamover-image-pull-policy", "IfNotPresent",
+	flag.StringVar(&datamoverImagePullPolicy, "datamover-image-pull-policy", "Always",
 		"Image pull policy for datamover pods (Always, IfNotPresent, Never)")
 	flag.StringVar(&oadpNamespace, "oadp-namespace", "openshift-adp",
 		"Namespace where OADP/Velero resources are located")

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -1377,7 +1377,7 @@ func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 
 	pullPolicy := r.DatamoverImagePullPolicy
 	if pullPolicy == "" {
-		pullPolicy = corev1.PullIfNotPresent
+		pullPolicy = corev1.PullAlways
 	}
 
 	return &DatamoverPodConfig{

--- a/pkg/common/validation.go
+++ b/pkg/common/validation.go
@@ -117,6 +117,19 @@ func ValidateVMForBackup(vm *kubevirtcorev1.VirtualMachine) error {
 	return nil
 }
 
+func getPvcNameFromVolume(volume kubevirtcorev1.Volume) string {
+	if volume.PersistentVolumeClaim != nil {
+		return volume.PersistentVolumeClaim.ClaimName
+	}
+	if volume.DataVolume != nil {
+		return volume.DataVolume.Name
+	}
+	if volume.MemoryDump != nil {
+		return volume.MemoryDump.ClaimName
+	}
+	return ""
+}
+
 // GetVolumesForVm returns a list of PVC names associated with the VirtualMachine.
 // It extracts PVC names from:
 // - PersistentVolumeClaim volume sources
@@ -125,28 +138,36 @@ func ValidateVMForBackup(vm *kubevirtcorev1.VirtualMachine) error {
 func GetVolumesForVm(vm *kubevirtcorev1.VirtualMachine) []string {
 	var pvcNames []string
 
-	if vm == nil {
-		return pvcNames
-	}
-
-	if vm.Spec.Template == nil || vm.Spec.Template.Spec.Volumes == nil {
+	if vm == nil || vm.Spec.Template == nil || vm.Spec.Template.Spec.Volumes == nil {
 		return pvcNames
 	}
 
 	for _, volume := range vm.Spec.Template.Spec.Volumes {
-		// Check for PersistentVolumeClaim source
-		if volume.PersistentVolumeClaim != nil {
-			pvcNames = append(pvcNames, volume.PersistentVolumeClaim.ClaimName)
-		}
-		// Check for DataVolume source (which creates a PVC with the same name)
-		if volume.DataVolume != nil {
-			pvcNames = append(pvcNames, volume.DataVolume.Name)
-		}
-		// Check for memory dump volume
-		if volume.MemoryDump != nil {
-			pvcNames = append(pvcNames, volume.MemoryDump.ClaimName)
+		if pvcName := getPvcNameFromVolume(volume); pvcName != "" {
+			pvcNames = append(pvcNames, pvcName)
 		}
 	}
 
 	return pvcNames
+}
+
+// GetVolumeMapForVm returns a map of volume names to PVC names associated with the VirtualMachine.
+// It extracts PVC names from:
+// - PersistentVolumeClaim volume sources
+// - DataVolume volume sources (which create PVCs with the same name)
+// - MemoryDump volume sources
+func GetVolumeMapForVm(vm *kubevirtcorev1.VirtualMachine) map[string]string {
+	volumeMap := make(map[string]string)
+
+	if vm == nil || vm.Spec.Template == nil || vm.Spec.Template.Spec.Volumes == nil {
+		return volumeMap
+	}
+
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		if pvcName := getPvcNameFromVolume(volume); pvcName != "" {
+			volumeMap[volume.Name] = pvcName
+		}
+	}
+
+	return volumeMap
 }

--- a/pkg/common/validation_test.go
+++ b/pkg/common/validation_test.go
@@ -141,6 +141,290 @@ func TestGetVMReference(t *testing.T) {
 	}
 }
 
+func TestGetVolumeMapForVm(t *testing.T) {
+	tests := []struct {
+		name     string
+		vm       *kubevirtcorev1.VirtualMachine
+		expected map[string]string
+	}{
+		{
+			name:     "nil VM",
+			vm:       nil,
+			expected: map[string]string{},
+		},
+		{
+			name: "VM with nil Template",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: nil,
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "VM with nil Volumes",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: nil,
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "VM with empty Volumes",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{},
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "VM with PVC volume",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "disk0",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+												ClaimName: "pvc-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{"disk0": "pvc-1"},
+		},
+		{
+			name: "VM with DataVolume",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "disk0",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										DataVolume: &kubevirtcorev1.DataVolumeSource{
+											Name: "dv-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{"disk0": "dv-1"},
+		},
+		{
+			name: "VM with MemoryDump volume",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "memory-dump",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										MemoryDump: &kubevirtcorev1.MemoryDumpVolumeSource{
+											PersistentVolumeClaimVolumeSource: kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+												PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+													ClaimName: "memory-dump-pvc",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{"memory-dump": "memory-dump-pvc"},
+		},
+		{
+			name: "VM with multiple volumes",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "disk0",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+												ClaimName: "pvc-1",
+											},
+										},
+									},
+								},
+								{
+									Name: "disk1",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										DataVolume: &kubevirtcorev1.DataVolumeSource{
+											Name: "dv-1",
+										},
+									},
+								},
+								{
+									Name: "disk2",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+												ClaimName: "pvc-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"disk0": "pvc-1",
+				"disk1": "dv-1",
+				"disk2": "pvc-2",
+			},
+		},
+		{
+			name: "VM with non-PVC volumes only",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "cloudinit",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										CloudInitNoCloud: &kubevirtcorev1.CloudInitNoCloudSource{
+											UserData: "test",
+										},
+									},
+								},
+								{
+									Name: "containerDisk",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										ContainerDisk: &kubevirtcorev1.ContainerDiskSource{
+											Image: "test-image",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "VM with mixed PVC and non-PVC volumes",
+			vm: &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "default",
+				},
+				Spec: kubevirtcorev1.VirtualMachineSpec{
+					Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+						Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+							Volumes: []kubevirtcorev1.Volume{
+								{
+									Name: "disk0",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+												ClaimName: "pvc-1",
+											},
+										},
+									},
+								},
+								{
+									Name: "cloudinit",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										CloudInitNoCloud: &kubevirtcorev1.CloudInitNoCloudSource{
+											UserData: "test",
+										},
+									},
+								},
+								{
+									Name: "disk1",
+									VolumeSource: kubevirtcorev1.VolumeSource{
+										DataVolume: &kubevirtcorev1.DataVolumeSource{
+											Name: "dv-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"disk0": "pvc-1",
+				"disk1": "dv-1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetVolumeMapForVm(tt.vm)
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestValidateVMIsRunning(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/uploader/run.go
+++ b/pkg/uploader/run.go
@@ -33,6 +33,7 @@ import (
 	velero "github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -109,7 +110,7 @@ func Run(ctx context.Context, logger logr.Logger) error {
 	logger.Info("Kube resources archived to S3")
 
 	// Update VM index (references the archived paths)
-	if err := updateVMIndex(ctx, store, config, files, archived, logger); err != nil {
+	if err := updateVMIndex(ctx, store, k8sClient, config, files, archived, logger); err != nil {
 		return fmt.Errorf("failed to update VM index: %w", err)
 	}
 
@@ -277,7 +278,7 @@ func extractDiskName(filename string) string {
 // that were uploaded by archiveKubeResources — these are stored on the
 // checkpoint entry so the index always references valid objects.
 func updateVMIndex(
-	ctx context.Context, store velero.ObjectStore, config *UploaderConfig,
+	ctx context.Context, store velero.ObjectStore, k8sClient client.Client, config *UploaderConfig,
 	files []CheckpointFile, archived *archivedPaths, logger logr.Logger,
 ) error {
 	indexPath := fmt.Sprintf("checkpoints/%s/%s/index.json", config.VMNamespace, config.VMName)
@@ -312,9 +313,17 @@ func updateVMIndex(
 	// Create new checkpoint entry
 	// Extract PVC/disk names from uploaded files
 	var pvcNames []string
+	var pvcSizes []resource.Quantity
 	for _, f := range files {
 		if f.DiskName != "" {
 			pvcNames = append(pvcNames, f.DiskName)
+			pvc := &corev1.PersistentVolumeClaim{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: f.DiskName, Namespace: config.VMNamespace}, pvc); err != nil {
+				return fmt.Errorf("failed to get PVC %s: %w", f.DiskName, err)
+			}
+			if storage, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+				pvcSizes = append(pvcSizes, storage)
+			}
 		}
 	}
 
@@ -331,6 +340,7 @@ func updateVMIndex(
 		VMBackup:       config.VMBName,
 		Files:          files,
 		PVCs:           pvcNames,
+		PVCSizes:       pvcSizes,
 		ReferencedBy:   referencedBy,
 		VMBObjectPath:  archived.VMBObjectPath,
 		VMBTObjectPath: archived.VMBTObjectPath,

--- a/pkg/uploader/run.go
+++ b/pkg/uploader/run.go
@@ -338,6 +338,8 @@ func updateVMIndex(
 			}
 			if storage, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
 				pvcSizes = append(pvcSizes, storage)
+			} else {
+				return fmt.Errorf("Missing storage request value in PVC %s", pvcName)
 			}
 		}
 	}

--- a/pkg/uploader/run.go
+++ b/pkg/uploader/run.go
@@ -329,7 +329,8 @@ func updateVMIndex(
 		if f.DiskName != "" {
 			pvcName := volumeMap[f.DiskName]
 			if pvcName == "" {
-				pvcName = f.DiskName
+				// Erroring out if there's a non-PVC volume
+				return fmt.Errorf("no PVC found for %s", f.DiskName)
 			}
 			pvcNames = append(pvcNames, pvcName)
 			pvc := &corev1.PersistentVolumeClaim{}

--- a/pkg/uploader/run.go
+++ b/pkg/uploader/run.go
@@ -339,7 +339,7 @@ func updateVMIndex(
 			if storage, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
 				pvcSizes = append(pvcSizes, storage)
 			} else {
-				return fmt.Errorf("Missing storage request value in PVC %s", pvcName)
+				return fmt.Errorf("missing storage request value in PVC %s", pvcName)
 			}
 		}
 	}

--- a/pkg/uploader/run.go
+++ b/pkg/uploader/run.go
@@ -314,7 +314,10 @@ func updateVMIndex(
 
 	// Create new checkpoint entry
 	vm := &kubevirtcorev1.VirtualMachine{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: config.VMName, Namespace: config.VMNamespace}, vm); err != nil {
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      config.VMName,
+		Namespace: config.VMNamespace,
+	}, vm); err != nil {
 		return fmt.Errorf("failed to get VM %s/%s: %w", config.VMNamespace, config.VMName, err)
 	}
 	volumeMap := common.GetVolumeMapForVm(vm)

--- a/pkg/uploader/run.go
+++ b/pkg/uploader/run.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kubevirtbackupv1alpha1 "kubevirt.io/api/backup/v1alpha1"
+	kubevirtcorev1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	restcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
@@ -311,15 +312,23 @@ func updateVMIndex(
 	}
 
 	// Create new checkpoint entry
+	vm := &kubevirtcorev1.VirtualMachine{}
+	_ = k8sClient.Get(ctx, types.NamespacedName{Name: config.VMName, Namespace: config.VMNamespace}, vm)
+	volumeMap := common.GetVolumeMapForVm(vm)
+
 	// Extract PVC/disk names from uploaded files
 	var pvcNames []string
 	var pvcSizes []resource.Quantity
 	for _, f := range files {
 		if f.DiskName != "" {
-			pvcNames = append(pvcNames, f.DiskName)
+			pvcName := volumeMap[f.DiskName]
+			if pvcName == "" {
+				pvcName = f.DiskName
+			}
+			pvcNames = append(pvcNames, pvcName)
 			pvc := &corev1.PersistentVolumeClaim{}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: f.DiskName, Namespace: config.VMNamespace}, pvc); err != nil {
-				return fmt.Errorf("failed to get PVC %s: %w", f.DiskName, err)
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: config.VMNamespace}, pvc); err != nil {
+				return fmt.Errorf("failed to get PVC %s: %w", pvcName, err)
 			}
 			if storage, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
 				pvcSizes = append(pvcSizes, storage)

--- a/pkg/uploader/run.go
+++ b/pkg/uploader/run.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	kubevirtbackupv1alpha1 "kubevirt.io/api/backup/v1alpha1"
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -313,7 +314,9 @@ func updateVMIndex(
 
 	// Create new checkpoint entry
 	vm := &kubevirtcorev1.VirtualMachine{}
-	_ = k8sClient.Get(ctx, types.NamespacedName{Name: config.VMName, Namespace: config.VMNamespace}, vm)
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: config.VMName, Namespace: config.VMNamespace}, vm); err != nil {
+		return fmt.Errorf("failed to get VM %s/%s: %w", config.VMNamespace, config.VMName, err)
+	}
 	volumeMap := common.GetVolumeMapForVm(vm)
 
 	// Extract PVC/disk names from uploaded files
@@ -681,8 +684,14 @@ func cleanupKubeResources(ctx context.Context, k8sClient client.Client, cfg *Upl
 // Extracted as a variable to allow overriding in tests.
 var newKubeClient = func() (client.Client, error) {
 	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
 	if err := kubevirtbackupv1alpha1.AddToScheme(scheme); err != nil {
 		return nil, fmt.Errorf("failed to register KubeVirt backup scheme: %w", err)
+	}
+	if err := kubevirtcorev1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to register KubeVirt scheme: %w", err)
 	}
 
 	restConfig, err := restcfg.GetConfig()

--- a/pkg/uploader/run_test.go
+++ b/pkg/uploader/run_test.go
@@ -555,7 +555,20 @@ func TestUpdateVMIndex(t *testing.T) {
 				tt.setupStore(store)
 			}
 
-			err := updateVMIndex(context.Background(), store, tt.config, tt.files, tt.archived, logr.Discard())
+			var objects []client.Object
+			for _, f := range tt.files {
+				if f.DiskName != "" {
+					objects = append(objects, &corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      f.DiskName,
+							Namespace: tt.config.VMNamespace,
+						},
+					})
+				}
+			}
+			fakeClient := fake.NewClientBuilder().WithObjects(objects...).Build()
+
+			err := updateVMIndex(context.Background(), store, fakeClient, tt.config, tt.files, tt.archived, logr.Discard())
 
 			if tt.expectError {
 				if err == nil {
@@ -1097,7 +1110,20 @@ func TestUpdateVMIndex_ReferencedByPropagation(t *testing.T) {
 				}
 			}
 
-			err := updateVMIndex(context.Background(), store, tt.config, tt.files, tt.archived, logr.Discard())
+			var objects []client.Object
+			for _, f := range tt.files {
+				if f.DiskName != "" {
+					objects = append(objects, &corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      f.DiskName,
+							Namespace: tt.config.VMNamespace,
+						},
+					})
+				}
+			}
+			fakeClient := fake.NewClientBuilder().WithObjects(objects...).Build()
+
+			err := updateVMIndex(context.Background(), store, fakeClient, tt.config, tt.files, tt.archived, logr.Discard())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1188,7 +1214,20 @@ func TestUpdateVMIndex_DedupIncrementalPreservesParent(t *testing.T) {
 			ObjectPath: "checkpoints/test-ns/test-vm/cp-002/vmb-2-disk1.qcow2"},
 	}
 
-	err := updateVMIndex(context.Background(), store, config, files, &archivedPaths{}, logr.Discard())
+	var objects []client.Object
+	for _, f := range files {
+		if f.DiskName != "" {
+			objects = append(objects, &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      f.DiskName,
+					Namespace: config.VMNamespace,
+				},
+			})
+		}
+	}
+	fakeClient := fake.NewClientBuilder().WithObjects(objects...).Build()
+
+	err := updateVMIndex(context.Background(), store, fakeClient, config, files, &archivedPaths{}, logr.Discard())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/uploader/run_test.go
+++ b/pkg/uploader/run_test.go
@@ -47,6 +47,7 @@ func getTestScheme() *runtime.Scheme {
 
 func getTestClientObjects(config *UploaderConfig, files []CheckpointFile) []client.Object {
 	var objects []client.Object
+	var volumes []kubevirtcorev1.Volume
 	for _, f := range files {
 		if f.DiskName != "" {
 			objects = append(objects, &corev1.PersistentVolumeClaim{
@@ -62,12 +63,27 @@ func getTestClientObjects(config *UploaderConfig, files []CheckpointFile) []clie
 					},
 				},
 			})
+			volumes = append(volumes, kubevirtcorev1.Volume{
+				Name: f.DiskName,
+				VolumeSource: kubevirtcorev1.VolumeSource{
+					DataVolume: &kubevirtcorev1.DataVolumeSource{
+						Name: f.DiskName,
+					},
+				},
+			})
 		}
 	}
 	objects = append(objects, &kubevirtcorev1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.VMName,
 			Namespace: config.VMNamespace,
+		},
+		Spec: kubevirtcorev1.VirtualMachineSpec{
+			Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+					Volumes: volumes,
+				},
+			},
 		},
 	})
 	return objects

--- a/pkg/uploader/run_test.go
+++ b/pkg/uploader/run_test.go
@@ -36,6 +36,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func getTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = kubevirtcorev1.AddToScheme(scheme)
+	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	return scheme
+}
+
 func TestExtractDiskName(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -255,9 +263,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 }
 
 func TestUpdateVMIndex(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = kubevirtcorev1.AddToScheme(scheme)
+	scheme := getTestScheme()
 
 	tests := []struct {
 		name           string
@@ -801,9 +807,7 @@ func TestPropagateReferencedBy(t *testing.T) {
 }
 
 func TestUpdateVMIndex_ReferencedByPropagation(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = kubevirtcorev1.AddToScheme(scheme)
+	scheme := getTestScheme()
 
 	tests := []struct {
 		name           string
@@ -1191,9 +1195,7 @@ func assertReferencedBy(t *testing.T, cpID string, got, want []string) {
 // incremental backup re-runs with the same checkpoint ID, the Parent field
 // is preserved from the existing entry (not corrupted to a self-reference).
 func TestUpdateVMIndex_DedupIncrementalPreservesParent(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = kubevirtcorev1.AddToScheme(scheme)
+	scheme := getTestScheme()
 	store := NewMockObjectStore("test-bucket", "")
 
 	existingIndex := &VMIndex{
@@ -1428,8 +1430,7 @@ func TestUpdateBackupManifests(t *testing.T) {
 }
 
 func TestArchiveKubeResources(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	scheme := getTestScheme()
 
 	apiGroup := "kubevirt.io"
 	backupAPIGroup := "backup.kubevirt.io"
@@ -1658,8 +1659,7 @@ func TestArchiveKubeResources(t *testing.T) {
 }
 
 func TestCleanupKubeResources(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	scheme := getTestScheme()
 
 	apiGroup := "kubevirt.io"
 	backupAPIGroup := "backup.kubevirt.io"
@@ -1769,8 +1769,7 @@ func TestCleanupKubeResources(t *testing.T) {
 // TestCleanupKubeResources_PreservesVMBT verifies that cleanupKubeResources
 // deletes the VMB but preserves the VMBT on-cluster (issue #32).
 func TestCleanupKubeResources_PreservesVMBT(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	scheme := getTestScheme()
 
 	apiGroup := "kubevirt.io"
 	backupAPIGroup := "backup.kubevirt.io"

--- a/pkg/uploader/run_test.go
+++ b/pkg/uploader/run_test.go
@@ -44,6 +44,27 @@ func getTestScheme() *runtime.Scheme {
 	return scheme
 }
 
+func getTestClientObjects(config *UploaderConfig, files []CheckpointFile) []client.Object {
+	var objects []client.Object
+	for _, f := range files {
+		if f.DiskName != "" {
+			objects = append(objects, &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      f.DiskName,
+					Namespace: config.VMNamespace,
+				},
+			})
+		}
+	}
+	objects = append(objects, &kubevirtcorev1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.VMName,
+			Namespace: config.VMNamespace,
+		},
+	})
+	return objects
+}
+
 func TestExtractDiskName(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -567,23 +588,7 @@ func TestUpdateVMIndex(t *testing.T) {
 				tt.setupStore(store)
 			}
 
-			var objects []client.Object
-			for _, f := range tt.files {
-				if f.DiskName != "" {
-					objects = append(objects, &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      f.DiskName,
-							Namespace: tt.config.VMNamespace,
-						},
-					})
-				}
-			}
-			objects = append(objects, &kubevirtcorev1.VirtualMachine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vm",
-					Namespace: "test-ns",
-				},
-			})
+			objects := getTestClientObjects(tt.config, tt.files)
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(objects...).Build()
@@ -1132,23 +1137,7 @@ func TestUpdateVMIndex_ReferencedByPropagation(t *testing.T) {
 				}
 			}
 
-			var objects []client.Object
-			for _, f := range tt.files {
-				if f.DiskName != "" {
-					objects = append(objects, &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      f.DiskName,
-							Namespace: tt.config.VMNamespace,
-						},
-					})
-				}
-			}
-			objects = append(objects, &kubevirtcorev1.VirtualMachine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vm",
-					Namespace: "test-ns",
-				},
-			})
+			objects := getTestClientObjects(tt.config, tt.files)
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(objects...).Build()
@@ -1245,23 +1234,7 @@ func TestUpdateVMIndex_DedupIncrementalPreservesParent(t *testing.T) {
 			ObjectPath: "checkpoints/test-ns/test-vm/cp-002/vmb-2-disk1.qcow2"},
 	}
 
-	var objects []client.Object
-	for _, f := range files {
-		if f.DiskName != "" {
-			objects = append(objects, &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      f.DiskName,
-					Namespace: config.VMNamespace,
-				},
-			})
-		}
-	}
-	objects = append(objects, &kubevirtcorev1.VirtualMachine{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vm",
-			Namespace: "test-ns",
-		},
-	})
+	objects := getTestClientObjects(config, files)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objects...).Build()

--- a/pkg/uploader/run_test.go
+++ b/pkg/uploader/run_test.go
@@ -29,7 +29,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	kubevirtbackupv1alpha1 "kubevirt.io/api/backup/v1alpha1"
+	kubevirtcorev1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -253,6 +255,10 @@ func TestLoadConfigFromEnv(t *testing.T) {
 }
 
 func TestUpdateVMIndex(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = kubevirtcorev1.AddToScheme(scheme)
+
 	tests := []struct {
 		name           string
 		config         *UploaderConfig
@@ -566,7 +572,15 @@ func TestUpdateVMIndex(t *testing.T) {
 					})
 				}
 			}
-			fakeClient := fake.NewClientBuilder().WithObjects(objects...).Build()
+			objects = append(objects, &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "test-ns",
+				},
+			})
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).Build()
 
 			err := updateVMIndex(context.Background(), store, fakeClient, tt.config, tt.files, tt.archived, logr.Discard())
 
@@ -787,6 +801,10 @@ func TestPropagateReferencedBy(t *testing.T) {
 }
 
 func TestUpdateVMIndex_ReferencedByPropagation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = kubevirtcorev1.AddToScheme(scheme)
+
 	tests := []struct {
 		name           string
 		config         *UploaderConfig
@@ -1121,7 +1139,15 @@ func TestUpdateVMIndex_ReferencedByPropagation(t *testing.T) {
 					})
 				}
 			}
-			fakeClient := fake.NewClientBuilder().WithObjects(objects...).Build()
+			objects = append(objects, &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "test-ns",
+				},
+			})
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).Build()
 
 			err := updateVMIndex(context.Background(), store, fakeClient, tt.config, tt.files, tt.archived, logr.Discard())
 			if err != nil {
@@ -1165,6 +1191,9 @@ func assertReferencedBy(t *testing.T, cpID string, got, want []string) {
 // incremental backup re-runs with the same checkpoint ID, the Parent field
 // is preserved from the existing entry (not corrupted to a self-reference).
 func TestUpdateVMIndex_DedupIncrementalPreservesParent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = kubevirtcorev1.AddToScheme(scheme)
 	store := NewMockObjectStore("test-bucket", "")
 
 	existingIndex := &VMIndex{
@@ -1225,7 +1254,15 @@ func TestUpdateVMIndex_DedupIncrementalPreservesParent(t *testing.T) {
 			})
 		}
 	}
-	fakeClient := fake.NewClientBuilder().WithObjects(objects...).Build()
+	objects = append(objects, &kubevirtcorev1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-vm",
+			Namespace: "test-ns",
+		},
+	})
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).Build()
 
 	err := updateVMIndex(context.Background(), store, fakeClient, config, files, &archivedPaths{}, logr.Discard())
 	if err != nil {

--- a/pkg/uploader/run_test.go
+++ b/pkg/uploader/run_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -52,6 +53,13 @@ func getTestClientObjects(config *UploaderConfig, files []CheckpointFile) []clie
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      f.DiskName,
 					Namespace: config.VMNamespace,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
 				},
 			})
 		}

--- a/pkg/uploader/types.go
+++ b/pkg/uploader/types.go
@@ -71,7 +71,11 @@ limitations under the License.
 // To restore backup-day3, the checkpointChain includes all three checkpoints.
 package uploader
 
-import "time"
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
 
 // Environment variable names for uploader configuration
 const (
@@ -177,6 +181,9 @@ type CheckpointEntry struct {
 
 	// PVCs is a list of PVC names backed up in this checkpoint (design field)
 	PVCs []string `json:"pvcs"`
+
+	// PVCSizes is a list of PVC storage request sizes matching the PVCs list
+	PVCSizes []resource.Quantity `json:"pvcSizes,omitempty"`
 
 	// ReferencedBy is a list of Velero backup names that reference this checkpoint (design field)
 	ReferencedBy []string `json:"referencedBy"`

--- a/pkg/uploader/types_test.go
+++ b/pkg/uploader/types_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestCheckpointEntryJSONSerialization(t *testing.T) {
@@ -45,6 +47,7 @@ func TestCheckpointEntryJSONSerialization(t *testing.T) {
 					},
 				},
 				PVCs:         []string{"disk1"},
+				PVCSizes:     []resource.Quantity{resource.MustParse("10Gi")},
 				ReferencedBy: []string{"backup-001"},
 			},
 			expectJSON: map[string]any{
@@ -52,6 +55,7 @@ func TestCheckpointEntryJSONSerialization(t *testing.T) {
 				"type":         "full",
 				"vmBackup":     "vmb-test",
 				"pvcs":         []any{"disk1"},
+				"pvcSizes":     []any{"10Gi"},
 				"referencedBy": []any{"backup-001"},
 			},
 		},
@@ -72,6 +76,7 @@ func TestCheckpointEntryJSONSerialization(t *testing.T) {
 					},
 				},
 				PVCs:         []string{"disk1"},
+				PVCSizes:     []resource.Quantity{resource.MustParse("10Gi")},
 				ReferencedBy: []string{"backup-002"},
 			},
 			expectJSON: map[string]any{
@@ -80,6 +85,7 @@ func TestCheckpointEntryJSONSerialization(t *testing.T) {
 				"parent":       "cp-001",
 				"vmBackup":     "vmb-test-2",
 				"pvcs":         []any{"disk1"},
+				"pvcSizes":     []any{"10Gi"},
 				"referencedBy": []any{"backup-002"},
 			},
 		},


### PR DESCRIPTION
This PR adds pvcSizes to the per-VM index file so on restore we won't need an additional APIServer call to know what size to create the PVC where we're copying the reconstructed filesystem.

In addition, this PR fixes a bug where we were listing the PVC name in the index as "volume0" or "volume1" rather than using the actual PVC name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Checkpoint metadata now includes PVC storage sizes for improved capacity visibility.

* **Improvements**
  * Image pull policy now defaults to Always when not configured, ensuring fresh datamover image pulls.
  * Stricter volume validation and a new VM volume→PVC mapping to more reliably resolve and report PVC references.

* **Tests**
  * Added unit tests covering VM volume→PVC mapping and uploader/index behavior with simulated Kubernetes objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->