### PR TITLE
feat: add --max-incremental-backups flag to cap chain length

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,6 +122,11 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	if maxIncrementalBackups < 0 {
+		fmt.Fprintln(os.Stderr, "--max-incremental-backups must be >= 0")
+		os.Exit(1)
+	}
+
 	// Allow DATAMOVER_IMAGE env var to override the default
 	// This enables kustomize to set the image via environment variable
 	if envImage := os.Getenv("DATAMOVER_IMAGE"); envImage != "" && datamoverImage == common.DefaultDatamoverImage {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,6 +87,7 @@ func main() {
 	var datamoverImage string
 	var datamoverImagePullPolicy string
 	var oadpNamespace string
+	var maxIncrementalBackups int
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -113,6 +114,8 @@ func main() {
 		"Image pull policy for datamover pods (Always, IfNotPresent, Never)")
 	flag.StringVar(&oadpNamespace, "oadp-namespace", "openshift-adp",
 		"Namespace where OADP/Velero resources are located")
+	flag.IntVar(&maxIncrementalBackups, "max-incremental-backups", 0,
+		"Maximum number of incremental backups per VM before forcing a full backup (0 = unlimited)")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -226,6 +229,7 @@ func main() {
 		MaxConcurrentReconciles:  maxConcurrentReconciles,
 		DatamoverImage:           datamoverImage,
 		DatamoverImagePullPolicy: corev1.PullPolicy(datamoverImagePullPolicy),
+		MaxIncrementalBackups:    maxIncrementalBackups,
 		OADPNamespace:            oadpNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeVirtDataUpload")

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -95,6 +96,10 @@ type KubeVirtDataUploadReconciler struct {
 
 	// DatamoverImagePullPolicy is the pull policy for the datamover image
 	DatamoverImagePullPolicy corev1.PullPolicy
+
+	// MaxIncrementalBackups is the maximum number of incremental backups per VM
+	// before forcing a full backup. 0 means unlimited.
+	MaxIncrementalBackups int
 
 	// ObjectStoreFactory creates an ObjectStore from an UploaderConfig.
 	// Defaults to uploader.InitObjectStore if nil. Override in tests to inject mocks.
@@ -499,9 +504,10 @@ func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 // resolveBackupMode determines whether to force a full backup or allow incremental.
 // Returns (forceFullBackup, checkpointLookup) where checkpointLookup is the BSL
 // chain validation result (nil if BSL was unreachable or validation was skipped).
-// This covers two scenarios:
+// This covers three scenarios:
 //  1. User explicitly requested force-full-backup via annotation on DataUpload.
 //  2. BSL checkpoint validation found a broken chain, requiring a forced full backup.
+//  3. Max incremental backups limit reached (global or per-VM override).
 func (r *KubeVirtDataUploadReconciler) resolveBackupMode(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, vmRef *common.VMReference) (bool, *uploader.CheckpointLookupResult) {
 	// Check if force full backup is requested via annotation.
 	if du.Annotations[common.AnnotationForceFullBackup] == bslValidatedValue {
@@ -518,7 +524,47 @@ func (r *KubeVirtDataUploadReconciler) resolveBackupMode(ctx context.Context, lo
 		return false, nil
 	}
 
-	return r.validateBSLCheckpoint(ctx, logger, du, vmRef)
+	forceFullBackup, checkpointLookup := r.validateBSLCheckpoint(ctx, logger, du, vmRef)
+
+	// Check if max incremental backups limit is reached.
+	// ChainLength includes the root full backup, so incrementals = ChainLength - 1.
+	if !forceFullBackup &&
+		checkpointLookup != nil && checkpointLookup.Found && checkpointLookup.IsChainValid {
+		maxInc := r.getEffectiveMaxIncrementalBackups(ctx, logger, vmRef)
+		if maxInc > 0 {
+			incrementalCount := checkpointLookup.ChainLength - 1
+			if incrementalCount >= maxInc {
+				logger.Info("Max incremental backups reached, forcing full backup",
+					"incrementalCount", incrementalCount,
+					"maxIncrementalBackups", maxInc,
+					"chainLength", checkpointLookup.ChainLength)
+				forceFullBackup = true
+			}
+		}
+	}
+
+	return forceFullBackup, checkpointLookup
+}
+
+// getEffectiveMaxIncrementalBackups returns the max incremental backups limit
+// for the given VM. A per-VM annotation takes precedence over the global setting.
+func (r *KubeVirtDataUploadReconciler) getEffectiveMaxIncrementalBackups(ctx context.Context, logger logr.Logger, vmRef *common.VMReference) int {
+	vm := &kubevirtcorev1.VirtualMachine{}
+	if err := r.Get(ctx, types.NamespacedName{Name: vmRef.Name, Namespace: vmRef.Namespace}, vm); err != nil {
+		logger.V(1).Info("Could not fetch VM for max-incremental-backups annotation, using global setting",
+			"reason", err.Error())
+		return r.MaxIncrementalBackups
+	}
+	if val, ok := vm.Annotations[common.AnnotationMaxIncrementalBackups]; ok {
+		if parsed, err := strconv.Atoi(val); err == nil && parsed >= 0 {
+			logger.Info("Using per-VM max incremental backups override",
+				"vm", vmRef.Name, "maxIncrementalBackups", parsed)
+			return parsed
+		}
+		logger.Info("Invalid max-incremental-backups annotation value, using global setting",
+			"vm", vmRef.Name, "annotationValue", val)
+	}
+	return r.MaxIncrementalBackups
 }
 
 // validateBSLCheckpoint queries the BSL for a valid checkpoint chain and determines

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -6465,3 +6465,554 @@ func TestCalculateBackupPVCSize(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveBackupMode_MaxIncrementalBackups(t *testing.T) {
+	buildChain := func(vmName, vmNamespace string, numIncrementals int) (uploader.VMIndex, []string) {
+		var checkpoints []uploader.CheckpointEntry
+		var files []string
+
+		fullPath := fmt.Sprintf("checkpoints/%s/%s/cp-000/disk.qcow2", vmNamespace, vmName)
+		checkpoints = append(checkpoints, uploader.CheckpointEntry{
+			ID:       "cp-000",
+			Type:     "full",
+			VMBackup: "vmb-000",
+			Files:    []uploader.CheckpointFile{{ObjectPath: fullPath}},
+		})
+		files = append(files, fullPath)
+
+		for i := 1; i <= numIncrementals; i++ {
+			cpID := fmt.Sprintf("cp-%03d", i)
+			parentID := fmt.Sprintf("cp-%03d", i-1)
+			path := fmt.Sprintf("checkpoints/%s/%s/%s/disk.qcow2", vmNamespace, vmName, cpID)
+			checkpoints = append(checkpoints, uploader.CheckpointEntry{
+				ID:       cpID,
+				Type:     "incremental",
+				Parent:   parentID,
+				VMBackup: fmt.Sprintf("vmb-%03d", i),
+				Files:    []uploader.CheckpointFile{{ObjectPath: path}},
+			})
+			files = append(files, path)
+		}
+
+		return uploader.VMIndex{
+			VMName:      vmName,
+			Namespace:   vmNamespace,
+			Checkpoints: checkpoints,
+		}, files
+	}
+
+	tests := []struct {
+		name                  string
+		maxIncrementalBackups int
+		numIncrementals       int
+		vmAnnotation          *string
+		wantForceFullBackup   bool
+	}{
+		{
+			name:                  "limit reached forces full backup",
+			maxIncrementalBackups: 3,
+			numIncrementals:       3,
+			wantForceFullBackup:   true,
+		},
+		{
+			name:                  "below limit allows incremental",
+			maxIncrementalBackups: 5,
+			numIncrementals:       2,
+			wantForceFullBackup:   false,
+		},
+		{
+			name:                  "unlimited (0) allows any chain length",
+			maxIncrementalBackups: 0,
+			numIncrementals:       9,
+			wantForceFullBackup:   false,
+		},
+		{
+			name:                  "exactly at boundary allows incremental",
+			maxIncrementalBackups: 3,
+			numIncrementals:       2,
+			wantForceFullBackup:   false,
+		},
+		{
+			name:                  "exceeded limit forces full backup",
+			maxIncrementalBackups: 3,
+			numIncrementals:       5,
+			wantForceFullBackup:   true,
+		},
+		{
+			name:                  "per-VM annotation overrides global to force full",
+			maxIncrementalBackups: 10,
+			numIncrementals:       3,
+			vmAnnotation:          strPtr("3"),
+			wantForceFullBackup:   true,
+		},
+		{
+			name:                  "per-VM annotation allows incremental when below its limit",
+			maxIncrementalBackups: 10,
+			numIncrementals:       2,
+			vmAnnotation:          strPtr("5"),
+			wantForceFullBackup:   false,
+		},
+		{
+			name:                  "per-VM annotation 0 means unlimited overriding global",
+			maxIncrementalBackups: 3,
+			numIncrementals:       9,
+			vmAnnotation:          strPtr("0"),
+			wantForceFullBackup:   false,
+		},
+		{
+			name:                  "invalid annotation falls back to global",
+			maxIncrementalBackups: 3,
+			numIncrementals:       3,
+			vmAnnotation:          strPtr("abc"),
+			wantForceFullBackup:   true,
+		},
+		{
+			name:                  "negative annotation falls back to global",
+			maxIncrementalBackups: 3,
+			numIncrementals:       3,
+			vmAnnotation:          strPtr("-1"),
+			wantForceFullBackup:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vmName := "test-vm"
+			vmNamespace := "test-ns"
+
+			scheme := runtime.NewScheme()
+			_ = velerov2alpha1.AddToScheme(scheme)
+			_ = velerov1.AddToScheme(scheme)
+			_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+			_ = kubevirtcorev1.AddToScheme(scheme)
+			_ = corev1.AddToScheme(scheme)
+
+			du := &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: vmNamespace,
+					UID:       types.UID("test-uid"),
+					Annotations: map[string]string{
+						common.AnnotationVMName:      vmName,
+						common.AnnotationVMNamespace: vmNamespace,
+					},
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover:             common.DataMoverKubeVirt,
+					SourceNamespace:       vmNamespace,
+					BackupStorageLocation: "default",
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: velerov2alpha1.DataUploadPhaseAccepted,
+				},
+			}
+
+			bsl := &velerov1.BackupStorageLocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: vmNamespace,
+				},
+				Spec: velerov1.BackupStorageLocationSpec{
+					Provider: "aws",
+					StorageType: velerov1.StorageType{
+						ObjectStorage: &velerov1.ObjectStorageLocation{
+							Bucket: "test-bucket",
+							Prefix: "velero",
+						},
+					},
+					Config: map[string]string{"region": "us-east-1"},
+					Credential: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "cloud-creds"},
+						Key:                  "cloud",
+					},
+				},
+				Status: velerov1.BackupStorageLocationStatus{
+					Phase: velerov1.BackupStorageLocationPhaseAvailable,
+				},
+			}
+
+			credSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cloud-creds",
+					Namespace: vmNamespace,
+				},
+				Data: map[string][]byte{
+					"cloud": []byte("[default]\naws_access_key_id=AKID\naws_secret_access_key=SECRET\n"),
+				},
+			}
+
+			vmAnnotations := map[string]string{}
+			if tt.vmAnnotation != nil {
+				vmAnnotations[common.AnnotationMaxIncrementalBackups] = *tt.vmAnnotation
+			}
+
+			vm := &kubevirtcorev1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        vmName,
+					Namespace:   vmNamespace,
+					Annotations: vmAnnotations,
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(du, bsl, credSecret, vm).
+				Build()
+
+			vmIndex, filePaths := buildChain(vmName, vmNamespace, tt.numIncrementals)
+			mockStore := uploader.NewMockObjectStore("test-bucket", "velero-kubevirt-datamover")
+			indexData, _ := json.Marshal(vmIndex)
+			_ = mockStore.PutObjectBytes(fmt.Sprintf("checkpoints/%s/%s/index.json", vmNamespace, vmName), indexData)
+			for _, path := range filePaths {
+				_ = mockStore.PutObjectBytes(path, []byte("data"))
+			}
+
+			r := &KubeVirtDataUploadReconciler{
+				Client:                fakeClient,
+				Scheme:                scheme,
+				Log:                   logr.Discard(),
+				OADPNamespace:         vmNamespace,
+				MaxIncrementalBackups: tt.maxIncrementalBackups,
+				ObjectStoreFactory: func(_ *uploader.UploaderConfig) (velero.ObjectStore, error) {
+					return mockStore, nil
+				},
+			}
+
+			vmRef := &common.VMReference{Name: vmName, Namespace: vmNamespace}
+			forceFullBackup, _ := r.resolveBackupMode(context.Background(), logr.Discard(), du, vmRef)
+
+			if forceFullBackup != tt.wantForceFullBackup {
+				t.Errorf("forceFullBackup = %v, want %v", forceFullBackup, tt.wantForceFullBackup)
+			}
+		})
+	}
+}
+
+func TestResolveBackupMode_MaxIncrementalSkippedOnBrokenChain(t *testing.T) {
+	vmName := "test-vm"
+	vmNamespace := "test-ns"
+
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = velerov1.AddToScheme(scheme)
+	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	_ = kubevirtcorev1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	du := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-du",
+			Namespace: vmNamespace,
+			UID:       types.UID("test-uid"),
+			Annotations: map[string]string{
+				common.AnnotationVMName:      vmName,
+				common.AnnotationVMNamespace: vmNamespace,
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover:             common.DataMoverKubeVirt,
+			SourceNamespace:       vmNamespace,
+			BackupStorageLocation: "default",
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseAccepted,
+		},
+	}
+
+	bsl := &velerov1.BackupStorageLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: vmNamespace,
+		},
+		Spec: velerov1.BackupStorageLocationSpec{
+			Provider: "aws",
+			StorageType: velerov1.StorageType{
+				ObjectStorage: &velerov1.ObjectStorageLocation{
+					Bucket: "test-bucket",
+					Prefix: "velero",
+				},
+			},
+			Config: map[string]string{"region": "us-east-1"},
+			Credential: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cloud-creds"},
+				Key:                  "cloud",
+			},
+		},
+		Status: velerov1.BackupStorageLocationStatus{
+			Phase: velerov1.BackupStorageLocationPhaseAvailable,
+		},
+	}
+
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cloud-creds",
+			Namespace: vmNamespace,
+		},
+		Data: map[string][]byte{
+			"cloud": []byte("[default]\naws_access_key_id=AKID\naws_secret_access_key=SECRET\n"),
+		},
+	}
+
+	vm := &kubevirtcorev1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmName,
+			Namespace: vmNamespace,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du, bsl, credSecret, vm).
+		Build()
+
+	vmIndex := uploader.VMIndex{
+		VMName:    vmName,
+		Namespace: vmNamespace,
+		Checkpoints: []uploader.CheckpointEntry{
+			{
+				ID:       "cp-000",
+				Type:     "full",
+				VMBackup: "vmb-000",
+				Files:    []uploader.CheckpointFile{{ObjectPath: "checkpoints/test-ns/test-vm/cp-000/disk.qcow2"}},
+			},
+			{
+				ID:       "cp-001",
+				Type:     "incremental",
+				Parent:   "cp-000",
+				VMBackup: "vmb-001",
+				Files:    []uploader.CheckpointFile{{ObjectPath: "checkpoints/test-ns/test-vm/cp-001/disk.qcow2"}},
+			},
+			{
+				ID:       "cp-002",
+				Type:     "incremental",
+				Parent:   "cp-001",
+				VMBackup: "vmb-002",
+				Files:    []uploader.CheckpointFile{{ObjectPath: "checkpoints/test-ns/test-vm/cp-002/disk.qcow2"}},
+			},
+		},
+	}
+	mockStore := uploader.NewMockObjectStore("test-bucket", "velero-kubevirt-datamover")
+	indexData, _ := json.Marshal(vmIndex)
+	_ = mockStore.PutObjectBytes("checkpoints/test-ns/test-vm/index.json", indexData)
+	_ = mockStore.PutObjectBytes("checkpoints/test-ns/test-vm/cp-000/disk.qcow2", []byte("full"))
+	_ = mockStore.PutObjectBytes("checkpoints/test-ns/test-vm/cp-002/disk.qcow2", []byte("inc2"))
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:                fakeClient,
+		Scheme:                scheme,
+		Log:                   logr.Discard(),
+		OADPNamespace:         vmNamespace,
+		MaxIncrementalBackups: 5,
+		ObjectStoreFactory: func(_ *uploader.UploaderConfig) (velero.ObjectStore, error) {
+			return mockStore, nil
+		},
+	}
+
+	vmRef := &common.VMReference{Name: vmName, Namespace: vmNamespace}
+	forceFullBackup, checkpointLookup := r.resolveBackupMode(context.Background(), logr.Discard(), du, vmRef)
+
+	if !forceFullBackup {
+		t.Error("expected forceFullBackup=true when chain is broken, regardless of MaxIncrementalBackups")
+	}
+	if checkpointLookup == nil {
+		t.Fatal("expected checkpointLookup to be returned")
+	}
+	if checkpointLookup.IsChainValid {
+		t.Error("expected IsChainValid=false for broken chain")
+	}
+}
+
+func TestResolveBackupMode_MaxIncrementalFirstBackup(t *testing.T) {
+	vmName := "test-vm"
+	vmNamespace := "test-ns"
+
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = velerov1.AddToScheme(scheme)
+	_ = kubevirtbackupv1alpha1.AddToScheme(scheme)
+	_ = kubevirtcorev1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	du := &velerov2alpha1.DataUpload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-du",
+			Namespace: vmNamespace,
+			UID:       types.UID("test-uid"),
+			Annotations: map[string]string{
+				common.AnnotationVMName:      vmName,
+				common.AnnotationVMNamespace: vmNamespace,
+			},
+		},
+		Spec: velerov2alpha1.DataUploadSpec{
+			DataMover:             common.DataMoverKubeVirt,
+			SourceNamespace:       vmNamespace,
+			BackupStorageLocation: "default",
+		},
+		Status: velerov2alpha1.DataUploadStatus{
+			Phase: velerov2alpha1.DataUploadPhaseAccepted,
+		},
+	}
+
+	bsl := &velerov1.BackupStorageLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: vmNamespace,
+		},
+		Spec: velerov1.BackupStorageLocationSpec{
+			Provider: "aws",
+			StorageType: velerov1.StorageType{
+				ObjectStorage: &velerov1.ObjectStorageLocation{
+					Bucket: "test-bucket",
+					Prefix: "velero",
+				},
+			},
+			Config: map[string]string{"region": "us-east-1"},
+			Credential: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cloud-creds"},
+				Key:                  "cloud",
+			},
+		},
+		Status: velerov1.BackupStorageLocationStatus{
+			Phase: velerov1.BackupStorageLocationPhaseAvailable,
+		},
+	}
+
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cloud-creds",
+			Namespace: vmNamespace,
+		},
+		Data: map[string][]byte{
+			"cloud": []byte("[default]\naws_access_key_id=AKID\naws_secret_access_key=SECRET\n"),
+		},
+	}
+
+	vm := &kubevirtcorev1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmName,
+			Namespace: vmNamespace,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(du, bsl, credSecret, vm).
+		Build()
+
+	mockStore := uploader.NewMockObjectStore("test-bucket", "velero-kubevirt-datamover")
+
+	r := &KubeVirtDataUploadReconciler{
+		Client:                fakeClient,
+		Scheme:                scheme,
+		Log:                   logr.Discard(),
+		OADPNamespace:         vmNamespace,
+		MaxIncrementalBackups: 1,
+		ObjectStoreFactory: func(_ *uploader.UploaderConfig) (velero.ObjectStore, error) {
+			return mockStore, nil
+		},
+	}
+
+	vmRef := &common.VMReference{Name: vmName, Namespace: vmNamespace}
+	forceFullBackup, checkpointLookup := r.resolveBackupMode(context.Background(), logr.Discard(), du, vmRef)
+
+	if !forceFullBackup {
+		t.Error("expected forceFullBackup=true for first backup (no checkpoint index)")
+	}
+	if checkpointLookup == nil {
+		t.Fatal("expected checkpointLookup to be returned")
+	}
+	if checkpointLookup.Found {
+		t.Error("expected Found=false for first backup")
+	}
+}
+
+func TestGetEffectiveMaxIncrementalBackups(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = kubevirtcorev1.AddToScheme(scheme)
+
+	tests := []struct {
+		name         string
+		globalMax    int
+		vmAnnotation *string
+		vmExists     bool
+		expectedMax  int
+	}{
+		{
+			name:        "no VM annotation uses global",
+			globalMax:   5,
+			vmExists:    true,
+			expectedMax: 5,
+		},
+		{
+			name:         "VM annotation overrides global",
+			globalMax:    5,
+			vmAnnotation: strPtr("3"),
+			vmExists:     true,
+			expectedMax:  3,
+		},
+		{
+			name:         "VM annotation 0 overrides global",
+			globalMax:    5,
+			vmAnnotation: strPtr("0"),
+			vmExists:     true,
+			expectedMax:  0,
+		},
+		{
+			name:         "invalid VM annotation falls back to global",
+			globalMax:    5,
+			vmAnnotation: strPtr("invalid"),
+			vmExists:     true,
+			expectedMax:  5,
+		},
+		{
+			name:         "negative VM annotation falls back to global",
+			globalMax:    5,
+			vmAnnotation: strPtr("-1"),
+			vmExists:     true,
+			expectedMax:  5,
+		},
+		{
+			name:        "VM not found falls back to global",
+			globalMax:   5,
+			vmExists:    false,
+			expectedMax: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []client.Object
+			if tt.vmExists {
+				annotations := map[string]string{}
+				if tt.vmAnnotation != nil {
+					annotations[common.AnnotationMaxIncrementalBackups] = *tt.vmAnnotation
+				}
+				objs = append(objs, &kubevirtcorev1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-vm",
+						Namespace:   "test-ns",
+						Annotations: annotations,
+					},
+				})
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				Build()
+
+			r := &KubeVirtDataUploadReconciler{
+				Client:                fakeClient,
+				Scheme:                scheme,
+				MaxIncrementalBackups: tt.globalMax,
+			}
+
+			vmRef := &common.VMReference{Name: "test-vm", Namespace: "test-ns"}
+			result := r.getEffectiveMaxIncrementalBackups(context.Background(), logr.Discard(), vmRef)
+
+			if result != tt.expectedMax {
+				t.Errorf("getEffectiveMaxIncrementalBackups() = %d, want %d", result, tt.expectedMax)
+			}
+		})
+	}
+}

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -54,6 +54,14 @@ const (
 	AnnotationDataUploadName = "velero.io/dataupload-name"
 )
 
+// Annotation keys for VirtualMachine resources
+const (
+	// AnnotationMaxIncrementalBackups, when set on a VirtualMachine, overrides
+	// the global --max-incremental-backups setting for that VM.
+	// The value must be a non-negative integer string (e.g., "5"). "0" means unlimited.
+	AnnotationMaxIncrementalBackups = "kubevirt-datamover.io/max-incremental-backups"
+)
+
 // Label keys for resources created by the controller.
 // Note: Kubernetes label values are limited to 63 characters. Use UIDs or
 // hashes (which have fixed length) as label values for lookups; store


### PR DESCRIPTION
## Summary
- Add `--max-incremental-backups` CLI flag (default 0 = unlimited) to limit incremental backup chain length per VM before forcing a full backup
- Add per-VM override via `kubevirt-datamover.io/max-incremental-backups` annotation on the VirtualMachine CR (takes precedence over global setting)
- Chain length check in `resolveBackupMode()` using existing `ChainLength` from BSL checkpoint validation

## OADP Operator companion PR
https://github.com/openshift/oadp-operator/pull/2179

## Test plan
- [x] Unit tests pass (18 new test cases covering global limit, per-VM override, boundary, broken chain, first backup, invalid annotation)
- [x] Deploy with companion operator PR and set `maxIncrementalBackups: 2` in DPA
- [x] Verified Full → Inc → Inc → Forced Full cycle (global limit)
- [x] Verified per-VM annotation override (`"1"`) shortens cycle to Full → Inc → Forced Full
- [x] Verified default (0 = unlimited) preserves existing behavior
- [x] Correct log messages at each decision point (`Max incremental backups reached`, `Using per-VM max incremental backups override`)

## Live cluster test results (maxIncrementalBackups: 2)

| Backup | Type | Chain Length | Incrementals | Reason |
|--------|------|-------------|--------------|--------|
| backup-2 | Full | 0 | 0 | First backup, no chain |
| backup-3 | Incremental | 1 | 0 | 0 < 2, allowed |
| backup-4 | Incremental | 2 | 1 | 1 < 2, allowed |
| backup-5 | **Full** | 3 | 2 | **2 >= 2, limit hit** |

## Per-VM annotation override (annotation: "1", global: 2)

| Backup | Type | Chain Length | Incrementals | Reason |
|--------|------|-------------|--------------|--------|
| backup-6 | Incremental | 1 | 0 | 0 < 1, allowed |
| backup-7 | **Full** | 2 | 1 | **1 >= 1, per-VM limit hit** |

Fixes: https://github.com/migtools/kubevirt-datamover-controller/issues/42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable incremental backup limits with global command-line flag setting and per-virtual machine annotation override support for granular control.

* **Tests**
  * Comprehensive unit tests for backup mode resolution, incremental backup limits, annotation parsing, and configuration fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->