### PR TITLE
fix: detect VMB failure when Done=True and size temp PVC from source disk

### DIFF
--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -415,6 +415,19 @@ func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 	}
 
 	if doneCond != nil && doneCond.Status == corev1.ConditionTrue {
+		// Done=True can mean "finished with error" — KubeVirt sets Done=True + Reason=Failed
+		// when the backup fails (e.g., "No space left on device"). Check Progressing condition.
+		if progressingCond != nil && progressingCond.Status == corev1.ConditionFalse &&
+			progressingCond.Reason == "Failed" {
+			logger.Error(nil, "VirtualMachineBackup failed (Done=True with failure)",
+				"vmb", vmb.Name, "reason", progressingCond.Reason, "message", progressingCond.Message)
+			if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
+				fmt.Sprintf("VMBackup failed: %s", progressingCond.Message)); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+
 		logger.Info("VirtualMachineBackup completed",
 			"vmb", vmb.Name,
 			"type", vmb.Status.Type,
@@ -952,6 +965,11 @@ func (r *KubeVirtDataUploadReconciler) filterKubeVirtDataMover() predicate.Predi
 }
 
 // ensureTempPVC creates or retrieves the temporary PVC for backup output.
+// The PVC is sized based on the source VM's disk size per issue #5:
+//  1. User override via annotation kubevirt-datamover.io/backup-pvc-size
+//  2. Source PVC capacity (from du.Spec.SourcePVC)
+//  3. Fallback to DefaultTempPVCSize (10Gi)
+//
 // Note: We don't set an owner reference because the PVC is in VM namespace
 // while DataUpload is in OADP namespace (cross-namespace owner refs not allowed).
 // The PVC will be cleaned up during PV rebinding or explicit cleanup.
@@ -967,6 +985,8 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 		logger.V(1).Info("Temporary PVC already exists", "pvc", pvcList.Items[0].Name)
 		return &pvcList.Items[0], nil
 	}
+
+	pvcSize := r.calculateBackupPVCSize(ctx, logger, du, namespace)
 
 	// Create new PVC
 	pvc := &corev1.PersistentVolumeClaim{
@@ -986,7 +1006,7 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 			},
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(DefaultTempPVCSize),
+					corev1.ResourceStorage: pvcSize,
 				},
 			},
 		},
@@ -996,8 +1016,54 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 		return nil, fmt.Errorf("failed to create temporary PVC: %w", err)
 	}
 
-	logger.Info("Created temporary PVC", "generateName", pvc.GenerateName, "namespace", namespace)
+	logger.Info("Created temporary PVC", "generateName", pvc.GenerateName, "namespace", namespace, "size", pvcSize.String())
 	return pvc, nil
+}
+
+// calculateBackupPVCSize determines the appropriate size for the temporary backup PVC.
+// Priority: user annotation > source PVC capacity > default 10Gi.
+func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, namespace string) resource.Quantity {
+	minSize := resource.MustParse("1Gi")
+	defaultSize := resource.MustParse(DefaultTempPVCSize)
+
+	// 1. Check user override annotation
+	if du.Annotations != nil {
+		if override := du.Annotations[common.AnnotationBackupPVCSize]; override != "" {
+			qty, err := resource.ParseQuantity(override)
+			if err != nil {
+				logger.Info("Invalid backup-pvc-size annotation, ignoring", "value", override, "error", err)
+			} else {
+				logger.Info("Using user-specified backup PVC size", "size", qty.String())
+				return qty
+			}
+		}
+	}
+
+	// 2. Look up source PVC capacity
+	sourcePVCName := du.Spec.SourcePVC
+	sourceNamespace := du.Spec.SourceNamespace
+	if sourceNamespace == "" {
+		sourceNamespace = namespace
+	}
+
+	if sourcePVCName != "" {
+		sourcePVC := &corev1.PersistentVolumeClaim{}
+		if err := r.Get(ctx, types.NamespacedName{Name: sourcePVCName, Namespace: sourceNamespace}, sourcePVC); err != nil {
+			logger.Info("Could not fetch source PVC for sizing, using default", "pvc", sourcePVCName, "error", err)
+			return defaultSize
+		}
+
+		if capacity, ok := sourcePVC.Status.Capacity[corev1.ResourceStorage]; ok {
+			if capacity.Cmp(minSize) < 0 {
+				return minSize
+			}
+			logger.Info("Sizing backup PVC from source PVC capacity", "sourcePVC", sourcePVCName, "size", capacity.String())
+			return capacity
+		}
+	}
+
+	// 3. Fallback
+	return defaultSize
 }
 
 // prepareVMBackupTracker returns an existing on-cluster VirtualMachineBackupTracker

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -665,6 +665,25 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			expectRequeue: true,
 		},
 		{
+			name: "VMB Done True with Failed reason transitions to Failed",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:    kubevirtbackupv1alpha1.ConditionProgressing,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Failed",
+					Message: "Backup has failed: No space left on device",
+				},
+				{
+					Type:    kubevirtbackupv1alpha1.ConditionDone,
+					Status:  corev1.ConditionTrue,
+					Reason:  "Failed",
+					Message: "Backup has failed: No space left on device",
+				},
+			},
+			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue: false,
+		},
+		{
 			name: "VMB Done False and Progressing False transitions to Failed",
 			vmbConditions: []kubevirtbackupv1alpha1.Condition{
 				{

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -44,6 +44,11 @@ const (
 	// ForceFullBackup=true. The new checkpoint replaces the old one in BSL.
 	AnnotationForceFullBackup = "kubevirt-datamover.io/force-full-backup"
 
+	// AnnotationBackupPVCSize, when set on a DataUpload, overrides the
+	// calculated temp PVC size. Value must be a valid Kubernetes quantity
+	// (e.g., "50Gi").
+	AnnotationBackupPVCSize = "kubevirt-datamover.io/backup-pvc-size"
+
 	// AnnotationDataUploadName is the annotation key for the DataUpload name.
 	// Used on VMB, VMBT, and PVC resources to track ownership.
 	AnnotationDataUploadName = "velero.io/dataupload-name"


### PR DESCRIPTION
## Summary

- **VMB failure detection**: `evaluateVMBackupStatus` treated `Done=True` as unconditional success, but KubeVirt sets `Done=True + Reason=Failed` when backup fails (e.g., "No space left on device"). The controller would proceed to launch the datamover pod which found no qcow2 files. Now checks `Progressing` condition for `Reason=Failed` before declaring success.
- **Dynamic PVC sizing** (closes #5): Replaces hardcoded 10Gi temp PVC with source PVC capacity. Supports user override via annotation `kubevirt-datamover.io/backup-pvc-size`.

## Test plan

- [x] New test case: `VMB Done True with Failed reason transitions to Failed`
- [x] All existing tests pass (`go test ./...`)
- [x] Deploy with test image and verify:
  - Backup of VM with disk > 10Gi creates appropriately sized temp PVC
  - VMB failure (e.g., disk full) correctly transitions DataUpload to Failed
  - User override annotation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)