### PR TITLE
fix: detect VMB failure when Done=True and size temp PVC from source disk

### DIFF
--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -415,6 +415,19 @@ func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 	}
 
 	if doneCond != nil && doneCond.Status == corev1.ConditionTrue {
+		// Done=True can mean "finished with error" — KubeVirt sets Done=True + Reason=Failed
+		// when the backup fails (e.g., "No space left on device"). Check Progressing condition.
+		if progressingCond != nil && progressingCond.Status == corev1.ConditionFalse &&
+			progressingCond.Reason == "Failed" {
+			logger.Error(nil, "VirtualMachineBackup failed (Done=True with failure)",
+				"vmb", vmb.Name, "reason", progressingCond.Reason, "message", progressingCond.Message)
+			if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
+				fmt.Sprintf("VMBackup failed: %s", progressingCond.Message)); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+
 		logger.Info("VirtualMachineBackup completed",
 			"vmb", vmb.Name,
 			"type", vmb.Status.Type,
@@ -952,6 +965,11 @@ func (r *KubeVirtDataUploadReconciler) filterKubeVirtDataMover() predicate.Predi
 }
 
 // ensureTempPVC creates or retrieves the temporary PVC for backup output.
+// The PVC is sized based on the source VM's disk size per issue #5:
+//  1. User override via annotation kubevirt-datamover.io/backup-pvc-size
+//  2. Source PVC capacity (from du.Spec.SourcePVC)
+//  3. Fallback to DefaultTempPVCSize (10Gi)
+//
 // Note: We don't set an owner reference because the PVC is in VM namespace
 // while DataUpload is in OADP namespace (cross-namespace owner refs not allowed).
 // The PVC will be cleaned up during PV rebinding or explicit cleanup.
@@ -967,6 +985,8 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 		logger.V(1).Info("Temporary PVC already exists", "pvc", pvcList.Items[0].Name)
 		return &pvcList.Items[0], nil
 	}
+
+	pvcSize := r.calculateBackupPVCSize(ctx, logger, du, namespace)
 
 	// Create new PVC
 	pvc := &corev1.PersistentVolumeClaim{
@@ -986,7 +1006,7 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 			},
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(DefaultTempPVCSize),
+					corev1.ResourceStorage: pvcSize,
 				},
 			},
 		},
@@ -996,8 +1016,54 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 		return nil, fmt.Errorf("failed to create temporary PVC: %w", err)
 	}
 
-	logger.Info("Created temporary PVC", "generateName", pvc.GenerateName, "namespace", namespace)
+	logger.Info("Created temporary PVC", "generateName", pvc.GenerateName, "namespace", namespace, "size", pvcSize.String())
 	return pvc, nil
+}
+
+// calculateBackupPVCSize determines the appropriate size for the temporary backup PVC.
+// Priority: user annotation > source PVC capacity > default 10Gi.
+func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, namespace string) resource.Quantity {
+	minSize := resource.MustParse("1Gi")
+	defaultSize := resource.MustParse(DefaultTempPVCSize)
+
+	// 1. Check user override annotation
+	if du.Annotations != nil {
+		if override := du.Annotations[common.AnnotationBackupPVCSize]; override != "" {
+			qty, err := resource.ParseQuantity(override)
+			if err != nil {
+				logger.Info("Invalid backup-pvc-size annotation, ignoring", "value", override, "error", err)
+			} else {
+				logger.Info("Using user-specified backup PVC size", "size", qty.String())
+				return qty
+			}
+		}
+	}
+
+	// 2. Look up source PVC capacity
+	sourcePVCName := du.Spec.SourcePVC
+	sourceNamespace := du.Spec.SourceNamespace
+	if sourceNamespace == "" {
+		sourceNamespace = namespace
+	}
+
+	if sourcePVCName != "" {
+		sourcePVC := &corev1.PersistentVolumeClaim{}
+		if err := r.Get(ctx, types.NamespacedName{Name: sourcePVCName, Namespace: sourceNamespace}, sourcePVC); err != nil {
+			logger.Info("Could not fetch source PVC for sizing, using default", "pvc", sourcePVCName, "error", err)
+			return defaultSize
+		}
+
+		if capacity, ok := sourcePVC.Status.Capacity[corev1.ResourceStorage]; ok {
+			if capacity.Cmp(minSize) < 0 {
+				return minSize
+			}
+			logger.Info("Sizing backup PVC from source PVC capacity", "sourcePVC", sourcePVCName, "size", capacity.String())
+			return capacity
+		}
+	}
+
+	// 3. Fallback
+	return defaultSize
 }
 
 // prepareVMBackupTracker returns an existing on-cluster VirtualMachineBackupTracker

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -1020,13 +1020,27 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 	return pvc, nil
 }
 
+// sizeOverheadPercent is the percentage added on top of source PVC capacity when
+// sizing the temporary backup PVC. This accounts for filesystem overhead (~6% on
+// ext4/xfs) and qcow2 metadata, ensuring the backup has enough room to complete.
+const sizeOverheadPercent = 20
+
 // calculateBackupPVCSize determines the appropriate size for the temporary backup PVC.
-// Priority: user annotation > source PVC capacity > default 10Gi.
+//
+// Priority:
+//  1. User override via annotation kubevirt-datamover.io/backup-pvc-size
+//  2. Source PVC capacity + 20% overhead (filesystem overhead + qcow2 metadata)
+//  3. Fallback to DefaultTempPVCSize (10Gi)
+//
+// The 20% overhead is necessary because:
+//   - Filesystem-mode PVCs lose ~6% to filesystem structures (ext4/xfs)
+//   - qcow2 files include metadata (header, L1/L2 tables, refcount blocks)
+//   - Without overhead, a full backup of a 30Gi disk can fail with ENOSPC on a 30Gi PVC
 func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, namespace string) resource.Quantity {
 	minSize := resource.MustParse("1Gi")
 	defaultSize := resource.MustParse(DefaultTempPVCSize)
 
-	// 1. Check user override annotation
+	// 1. Check user override annotation — allows explicit size when heuristics don't fit
 	if du.Annotations != nil {
 		if override := du.Annotations[common.AnnotationBackupPVCSize]; override != "" {
 			qty, err := resource.ParseQuantity(override)
@@ -1039,7 +1053,7 @@ func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Contex
 		}
 	}
 
-	// 2. Look up source PVC capacity
+	// 2. Look up source PVC capacity and add overhead
 	sourcePVCName := du.Spec.SourcePVC
 	sourceNamespace := du.Spec.SourceNamespace
 	if sourceNamespace == "" {
@@ -1054,16 +1068,30 @@ func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Contex
 		}
 
 		if capacity, ok := sourcePVC.Status.Capacity[corev1.ResourceStorage]; ok {
-			if capacity.Cmp(minSize) < 0 {
+			withOverhead := addOverhead(capacity, sizeOverheadPercent)
+			if withOverhead.Cmp(minSize) < 0 {
 				return minSize
 			}
-			logger.Info("Sizing backup PVC from source PVC capacity", "sourcePVC", sourcePVCName, "size", capacity.String())
-			return capacity
+			logger.Info("Sizing backup PVC from source PVC capacity",
+				"sourcePVC", sourcePVCName,
+				"sourceCapacity", capacity.String(),
+				"overheadPercent", sizeOverheadPercent,
+				"finalSize", withOverhead.String())
+			return withOverhead
 		}
 	}
 
 	// 3. Fallback
 	return defaultSize
+}
+
+// addOverhead returns qty increased by the given percentage.
+// For example, addOverhead(30Gi, 20) returns 36Gi.
+func addOverhead(qty resource.Quantity, percent int64) resource.Quantity {
+	base := qty.Value()
+	overhead := base * percent / 100
+	result := resource.NewQuantity(base+overhead, resource.BinarySI)
+	return *result
 }
 
 // prepareVMBackupTracker returns an existing on-cluster VirtualMachineBackupTracker

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -986,7 +986,10 @@ func (r *KubeVirtDataUploadReconciler) ensureTempPVC(ctx context.Context, logger
 		return &pvcList.Items[0], nil
 	}
 
-	pvcSize := r.calculateBackupPVCSize(ctx, logger, du, namespace)
+	pvcSize, err := r.calculateBackupPVCSize(ctx, logger, du, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to calculate backup PVC size: %w", err)
+	}
 
 	// Create new PVC
 	pvc := &corev1.PersistentVolumeClaim{
@@ -1029,14 +1032,20 @@ const sizeOverheadPercent = 20
 //
 // Priority:
 //  1. User override via annotation kubevirt-datamover.io/backup-pvc-size
-//  2. Source PVC capacity + 20% overhead (filesystem overhead + qcow2 metadata)
-//  3. Fallback to DefaultTempPVCSize (10Gi)
+//  2. Sum of all VM disk PVC capacities + 20% overhead
+//  3. Source PVC capacity + 20% overhead (fallback if VM lookup fails)
+//  4. Fallback to DefaultTempPVCSize (10Gi)
 //
-// The 20% overhead is necessary because:
-//   - Filesystem-mode PVCs lose ~6% to filesystem structures (ext4/xfs)
-//   - qcow2 files include metadata (header, L1/L2 tables, refcount blocks)
-//   - Without overhead, a full backup of a 30Gi disk can fail with ENOSPC on a 30Gi PVC
-func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, namespace string) resource.Quantity {
+// For multi-disk VMs, KubeVirt writes all volumes' backup data into a single temp PVC,
+// so we must sum all disk sizes. The 20% overhead accounts for:
+//   - Filesystem-mode PVCs losing ~6% to filesystem structures (ext4/xfs)
+//   - qcow2 metadata (header, L1/L2 tables, refcount blocks)
+//   - Without overhead, a full backup of a 30Gi disk fails with ENOSPC on a 30Gi PVC
+//
+// Error handling: NotFound errors on PVC lookups are fatal (the VM references a
+// volume that doesn't exist — the backup will fail anyway). Other errors (RBAC,
+// cache not synced) fall back to the default to avoid infinite reconcile retries.
+func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, namespace string) (resource.Quantity, error) {
 	minSize := resource.MustParse("1Gi")
 	defaultSize := resource.MustParse(DefaultTempPVCSize)
 
@@ -1048,41 +1057,83 @@ func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Contex
 				logger.Info("Invalid backup-pvc-size annotation, ignoring", "value", override, "error", err)
 			} else {
 				logger.Info("Using user-specified backup PVC size", "size", qty.String())
-				return qty
+				return qty, nil
 			}
 		}
 	}
 
-	// 2. Look up source PVC capacity and add overhead
-	sourcePVCName := du.Spec.SourcePVC
 	sourceNamespace := du.Spec.SourceNamespace
 	if sourceNamespace == "" {
 		sourceNamespace = namespace
 	}
 
+	// 2. Sum all VM disk PVC capacities (handles multi-disk VMs correctly since
+	// KubeVirt writes all volumes' backup data into a single temp PVC)
+	vmRef, err := common.GetVMReference(du)
+	if err == nil {
+		vm := &kubevirtcorev1.VirtualMachine{}
+		if err := r.Get(ctx, types.NamespacedName{Name: vmRef.Name, Namespace: vmRef.Namespace}, vm); err == nil {
+			pvcNames := common.GetVolumesForVm(vm)
+			if len(pvcNames) > 0 {
+				totalCapacity := resource.Quantity{}
+				for _, pvcName := range pvcNames {
+					pvc := &corev1.PersistentVolumeClaim{}
+					if err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: vmRef.Namespace}, pvc); err != nil {
+						if errors.IsNotFound(err) {
+							return resource.Quantity{}, fmt.Errorf("VM PVC %s/%s not found, cannot determine backup size", vmRef.Namespace, pvcName)
+						}
+						logger.Info("Could not fetch VM PVC for sizing, skipping", "pvc", pvcName, "error", err)
+						continue
+					}
+					if capacity, ok := pvc.Status.Capacity[corev1.ResourceStorage]; ok {
+						totalCapacity.Add(capacity)
+					}
+				}
+				if !totalCapacity.IsZero() {
+					withOverhead := addOverhead(totalCapacity, sizeOverheadPercent)
+					if withOverhead.Cmp(minSize) < 0 {
+						withOverhead = minSize
+					}
+					logger.Info("Sizing backup PVC from VM disk capacities",
+						"vmName", vmRef.Name,
+						"diskCount", len(pvcNames),
+						"totalCapacity", totalCapacity.String(),
+						"overheadPercent", sizeOverheadPercent,
+						"finalSize", withOverhead.String())
+					return withOverhead, nil
+				}
+			}
+		}
+	}
+
+	// 3. Fall back to source PVC from DataUpload spec (single-disk fallback path)
+	sourcePVCName := du.Spec.SourcePVC
 	if sourcePVCName != "" {
 		sourcePVC := &corev1.PersistentVolumeClaim{}
 		if err := r.Get(ctx, types.NamespacedName{Name: sourcePVCName, Namespace: sourceNamespace}, sourcePVC); err != nil {
+			if errors.IsNotFound(err) {
+				return resource.Quantity{}, fmt.Errorf("source PVC %s/%s not found, cannot determine backup size", sourceNamespace, sourcePVCName)
+			}
 			logger.Info("Could not fetch source PVC for sizing, using default", "pvc", sourcePVCName, "error", err)
-			return defaultSize
+			return defaultSize, nil
 		}
 
 		if capacity, ok := sourcePVC.Status.Capacity[corev1.ResourceStorage]; ok {
 			withOverhead := addOverhead(capacity, sizeOverheadPercent)
 			if withOverhead.Cmp(minSize) < 0 {
-				return minSize
+				withOverhead = minSize
 			}
 			logger.Info("Sizing backup PVC from source PVC capacity",
 				"sourcePVC", sourcePVCName,
 				"sourceCapacity", capacity.String(),
 				"overheadPercent", sizeOverheadPercent,
 				"finalSize", withOverhead.String())
-			return withOverhead
+			return withOverhead, nil
 		}
 	}
 
-	// 3. Fallback
-	return defaultSize
+	// 4. Fallback
+	return defaultSize, nil
 }
 
 // addOverhead returns qty increased by the given percentage.

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -276,6 +276,16 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 	// Step 1: Create or get temporary PVC for backup output
 	pvc, err := r.ensureTempPVC(ctx, logger, du, vmRef.Namespace)
 	if err != nil {
+		// If a referenced PVC is permanently missing, fail the DataUpload
+		// instead of retrying forever. errors.IsNotFound matches wrapped errors.
+		if errors.IsNotFound(err) {
+			logger.Error(err, "PVC not found, failing DataUpload")
+			if updateErr := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
+				fmt.Sprintf("Failed to create backup PVC: %v", err)); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+			return ctrl.Result{}, nil
+		}
 		logger.Error(err, "Failed to ensure temporary PVC")
 		return ctrl.Result{}, err
 	}
@@ -1080,10 +1090,13 @@ func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Contex
 					pvc := &corev1.PersistentVolumeClaim{}
 					if err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: vmRef.Namespace}, pvc); err != nil {
 						if errors.IsNotFound(err) {
-							return resource.Quantity{}, fmt.Errorf("VM PVC %s/%s not found, cannot determine backup size", vmRef.Namespace, pvcName)
+							return resource.Quantity{}, fmt.Errorf("VM PVC %s/%s not found, cannot determine backup size: %w", vmRef.Namespace, pvcName, err)
 						}
-						logger.Info("Could not fetch VM PVC for sizing, skipping", "pvc", pvcName, "error", err)
-						continue
+						// Transient error — abort VM-based sizing and fall to source PVC fallback
+						// to avoid creating an undersized PVC from a partial sum
+						logger.Info("Could not fetch VM PVC for sizing, falling back to source PVC", "pvc", pvcName, "error", err)
+						totalCapacity = resource.Quantity{}
+						break
 					}
 					if capacity, ok := pvc.Status.Capacity[corev1.ResourceStorage]; ok {
 						totalCapacity.Add(capacity)
@@ -1112,7 +1125,7 @@ func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Contex
 		sourcePVC := &corev1.PersistentVolumeClaim{}
 		if err := r.Get(ctx, types.NamespacedName{Name: sourcePVCName, Namespace: sourceNamespace}, sourcePVC); err != nil {
 			if errors.IsNotFound(err) {
-				return resource.Quantity{}, fmt.Errorf("source PVC %s/%s not found, cannot determine backup size", sourceNamespace, sourcePVCName)
+				return resource.Quantity{}, fmt.Errorf("source PVC %s/%s not found, cannot determine backup size: %w", sourceNamespace, sourcePVCName, err)
 			}
 			logger.Info("Could not fetch source PVC for sizing, using default", "pvc", sourcePVCName, "error", err)
 			return defaultSize, nil

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -6139,3 +6139,217 @@ func TestCleanupVMBackupResources_PreservesVMBT(t *testing.T) {
 		t.Errorf("VMBT should have been preserved during cleanup, but it was deleted: %v", err)
 	}
 }
+
+func TestAddOverhead(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		percent  int64
+		expected string
+	}{
+		{
+			name:     "20% overhead on 30Gi",
+			input:    "30Gi",
+			percent:  20,
+			expected: "36Gi",
+		},
+		{
+			name:     "20% overhead on 10Gi",
+			input:    "10Gi",
+			percent:  20,
+			expected: "12Gi",
+		},
+		{
+			name:    "20% overhead on 1Gi",
+			input:   "1Gi",
+			percent: 20,
+			// 1Gi = 1073741824 bytes, 20% = 214748364, total = 1288490188
+			expected: "1288490188",
+		},
+		{
+			name:     "0% overhead returns same value",
+			input:    "50Gi",
+			percent:  0,
+			expected: "50Gi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := resource.MustParse(tt.input)
+			result := addOverhead(input, tt.percent)
+			expected := resource.MustParse(tt.expected)
+			if result.Cmp(expected) != 0 {
+				t.Errorf("addOverhead(%s, %d%%) = %s, want %s", tt.input, tt.percent, result.String(), expected.String())
+			}
+		})
+	}
+}
+
+func TestCalculateBackupPVCSize(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	tests := []struct {
+		name         string
+		du           *velerov2alpha1.DataUpload
+		sourcePVC    *corev1.PersistentVolumeClaim // nil = don't create
+		expectedSize string
+	}{
+		{
+			name: "sizes from source PVC capacity with 20% overhead",
+			du: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-du", Namespace: "openshift-adp"},
+				Spec: velerov2alpha1.DataUploadSpec{
+					SourcePVC:       "source-disk",
+					SourceNamespace: "vm-ns",
+				},
+			},
+			sourcePVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "source-disk", Namespace: "vm-ns"},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Capacity: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("30Gi"),
+					},
+				},
+			},
+			expectedSize: "36Gi",
+		},
+		{
+			name: "user annotation overrides source PVC",
+			du: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+					Annotations: map[string]string{
+						common.AnnotationBackupPVCSize: "50Gi",
+					},
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					SourcePVC:       "source-disk",
+					SourceNamespace: "vm-ns",
+				},
+			},
+			sourcePVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "source-disk", Namespace: "vm-ns"},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Capacity: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("30Gi"),
+					},
+				},
+			},
+			expectedSize: "50Gi",
+		},
+		{
+			name: "invalid annotation falls through to source PVC",
+			du: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+					Annotations: map[string]string{
+						common.AnnotationBackupPVCSize: "not-a-quantity",
+					},
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					SourcePVC:       "source-disk",
+					SourceNamespace: "vm-ns",
+				},
+			},
+			sourcePVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "source-disk", Namespace: "vm-ns"},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Capacity: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("10Gi"),
+					},
+				},
+			},
+			expectedSize: "12Gi",
+		},
+		{
+			name: "falls back to default when source PVC not found",
+			du: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-du", Namespace: "openshift-adp"},
+				Spec: velerov2alpha1.DataUploadSpec{
+					SourcePVC:       "nonexistent-disk",
+					SourceNamespace: "vm-ns",
+				},
+			},
+			sourcePVC:    nil,
+			expectedSize: DefaultTempPVCSize,
+		},
+		{
+			name: "falls back to default when no source PVC specified",
+			du: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-du", Namespace: "openshift-adp"},
+				Spec:       velerov2alpha1.DataUploadSpec{},
+			},
+			sourcePVC:    nil,
+			expectedSize: DefaultTempPVCSize,
+		},
+		{
+			name: "enforces minimum 1Gi floor",
+			du: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-du", Namespace: "openshift-adp"},
+				Spec: velerov2alpha1.DataUploadSpec{
+					SourcePVC:       "tiny-disk",
+					SourceNamespace: "vm-ns",
+				},
+			},
+			sourcePVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "tiny-disk", Namespace: "vm-ns"},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Capacity: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("500Mi"),
+					},
+				},
+			},
+			expectedSize: "1Gi",
+		},
+		{
+			name: "uses SourceNamespace from DataUpload spec",
+			du: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-du", Namespace: "openshift-adp"},
+				Spec: velerov2alpha1.DataUploadSpec{
+					SourcePVC:       "disk-in-other-ns",
+					SourceNamespace: "other-ns",
+				},
+			},
+			sourcePVC: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "disk-in-other-ns", Namespace: "other-ns"},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Capacity: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("20Gi"),
+					},
+				},
+			},
+			expectedSize: "24Gi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []client.Object{}
+			if tt.sourcePVC != nil {
+				objs = append(objs, tt.sourcePVC)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				Build()
+
+			r := &KubeVirtDataUploadReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			logger := logr.Discard()
+			result := r.calculateBackupPVCSize(context.Background(), logger, tt.du, "vm-ns")
+			expected := resource.MustParse(tt.expectedSize)
+
+			if result.Cmp(expected) != 0 {
+				t.Errorf("calculateBackupPVCSize() = %s, want %s", result.String(), expected.String())
+			}
+		})
+	}
+}

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -6190,12 +6190,14 @@ func TestCalculateBackupPVCSize(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = velerov2alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = kubevirtcorev1.AddToScheme(scheme)
 
 	tests := []struct {
 		name         string
 		du           *velerov2alpha1.DataUpload
-		sourcePVC    *corev1.PersistentVolumeClaim // nil = don't create
+		objects      []client.Object // PVCs, VMs, etc.
 		expectedSize string
+		expectErr    bool
 	}{
 		{
 			name: "sizes from source PVC capacity with 20% overhead",
@@ -6206,11 +6208,13 @@ func TestCalculateBackupPVCSize(t *testing.T) {
 					SourceNamespace: "vm-ns",
 				},
 			},
-			sourcePVC: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "source-disk", Namespace: "vm-ns"},
-				Status: corev1.PersistentVolumeClaimStatus{
-					Capacity: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("30Gi"),
+			objects: []client.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "source-disk", Namespace: "vm-ns"},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Capacity: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("30Gi"),
+						},
 					},
 				},
 			},
@@ -6231,11 +6235,13 @@ func TestCalculateBackupPVCSize(t *testing.T) {
 					SourceNamespace: "vm-ns",
 				},
 			},
-			sourcePVC: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "source-disk", Namespace: "vm-ns"},
-				Status: corev1.PersistentVolumeClaimStatus{
-					Capacity: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("30Gi"),
+			objects: []client.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "source-disk", Namespace: "vm-ns"},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Capacity: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("30Gi"),
+						},
 					},
 				},
 			},
@@ -6256,18 +6262,20 @@ func TestCalculateBackupPVCSize(t *testing.T) {
 					SourceNamespace: "vm-ns",
 				},
 			},
-			sourcePVC: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "source-disk", Namespace: "vm-ns"},
-				Status: corev1.PersistentVolumeClaimStatus{
-					Capacity: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("10Gi"),
+			objects: []client.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "source-disk", Namespace: "vm-ns"},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Capacity: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("10Gi"),
+						},
 					},
 				},
 			},
 			expectedSize: "12Gi",
 		},
 		{
-			name: "falls back to default when source PVC not found",
+			name: "source PVC not found returns error",
 			du: &velerov2alpha1.DataUpload{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-du", Namespace: "openshift-adp"},
 				Spec: velerov2alpha1.DataUploadSpec{
@@ -6275,8 +6283,8 @@ func TestCalculateBackupPVCSize(t *testing.T) {
 					SourceNamespace: "vm-ns",
 				},
 			},
-			sourcePVC:    nil,
-			expectedSize: DefaultTempPVCSize,
+			objects:   nil,
+			expectErr: true,
 		},
 		{
 			name: "falls back to default when no source PVC specified",
@@ -6284,7 +6292,7 @@ func TestCalculateBackupPVCSize(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-du", Namespace: "openshift-adp"},
 				Spec:       velerov2alpha1.DataUploadSpec{},
 			},
-			sourcePVC:    nil,
+			objects:      nil,
 			expectedSize: DefaultTempPVCSize,
 		},
 		{
@@ -6296,11 +6304,13 @@ func TestCalculateBackupPVCSize(t *testing.T) {
 					SourceNamespace: "vm-ns",
 				},
 			},
-			sourcePVC: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "tiny-disk", Namespace: "vm-ns"},
-				Status: corev1.PersistentVolumeClaimStatus{
-					Capacity: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("500Mi"),
+			objects: []client.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "tiny-disk", Namespace: "vm-ns"},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Capacity: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("500Mi"),
+						},
 					},
 				},
 			},
@@ -6315,23 +6325,115 @@ func TestCalculateBackupPVCSize(t *testing.T) {
 					SourceNamespace: "other-ns",
 				},
 			},
-			sourcePVC: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "disk-in-other-ns", Namespace: "other-ns"},
-				Status: corev1.PersistentVolumeClaimStatus{
-					Capacity: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("20Gi"),
+			objects: []client.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "disk-in-other-ns", Namespace: "other-ns"},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Capacity: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("20Gi"),
+						},
 					},
 				},
 			},
 			expectedSize: "24Gi",
+		},
+		{
+			name: "multi-disk VM sums all PVC capacities",
+			du: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+					Annotations: map[string]string{
+						common.AnnotationVMName:      "multi-disk-vm",
+						common.AnnotationVMNamespace: "vm-ns",
+					},
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					SourcePVC:       "disk-1",
+					SourceNamespace: "vm-ns",
+				},
+			},
+			objects: []client.Object{
+				&kubevirtcorev1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{Name: "multi-disk-vm", Namespace: "vm-ns"},
+					Spec: kubevirtcorev1.VirtualMachineSpec{
+						Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtcorev1.Volume{
+									{Name: "vol1", VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "disk-1"},
+										},
+									}},
+									{Name: "vol2", VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "disk-2"},
+										},
+									}},
+								},
+							},
+						},
+					},
+				},
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "disk-1", Namespace: "vm-ns"},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("30Gi")},
+					},
+				},
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "disk-2", Namespace: "vm-ns"},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("20Gi")},
+					},
+				},
+			},
+			// 30Gi + 20Gi = 50Gi, +20% = 60Gi
+			expectedSize: "60Gi",
+		},
+		{
+			name: "multi-disk VM with missing PVC returns error",
+			du: &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+					Annotations: map[string]string{
+						common.AnnotationVMName:      "vm-missing-pvc",
+						common.AnnotationVMNamespace: "vm-ns",
+					},
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					SourcePVC:       "disk-1",
+					SourceNamespace: "vm-ns",
+				},
+			},
+			objects: []client.Object{
+				&kubevirtcorev1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{Name: "vm-missing-pvc", Namespace: "vm-ns"},
+					Spec: kubevirtcorev1.VirtualMachineSpec{
+						Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtcorev1.Volume{
+									{Name: "vol1", VolumeSource: kubevirtcorev1.VolumeSource{
+										PersistentVolumeClaim: &kubevirtcorev1.PersistentVolumeClaimVolumeSource{
+											PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "disk-that-doesnt-exist"},
+										},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			objs := []client.Object{}
-			if tt.sourcePVC != nil {
-				objs = append(objs, tt.sourcePVC)
+			if tt.objects != nil {
+				objs = append(objs, tt.objects...)
 			}
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -6344,9 +6446,19 @@ func TestCalculateBackupPVCSize(t *testing.T) {
 			}
 
 			logger := logr.Discard()
-			result := r.calculateBackupPVCSize(context.Background(), logger, tt.du, "vm-ns")
-			expected := resource.MustParse(tt.expectedSize)
+			result, err := r.calculateBackupPVCSize(context.Background(), logger, tt.du, "vm-ns")
 
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("calculateBackupPVCSize() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("calculateBackupPVCSize() unexpected error: %v", err)
+			}
+
+			expected := resource.MustParse(tt.expectedSize)
 			if result.Cmp(expected) != 0 {
 				t.Errorf("calculateBackupPVCSize() = %s, want %s", result.String(), expected.String())
 			}

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -665,6 +665,25 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 			expectRequeue: true,
 		},
 		{
+			name: "VMB Done True with Failed reason transitions to Failed",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:    kubevirtbackupv1alpha1.ConditionProgressing,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Failed",
+					Message: "Backup has failed: No space left on device",
+				},
+				{
+					Type:    kubevirtbackupv1alpha1.ConditionDone,
+					Status:  corev1.ConditionTrue,
+					Reason:  "Failed",
+					Message: "Backup has failed: No space left on device",
+				},
+			},
+			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue: false,
+		},
+		{
 			name: "VMB Done False and Progressing False transitions to Failed",
 			vmbConditions: []kubevirtbackupv1alpha1.Condition{
 				{

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -44,6 +44,11 @@ const (
 	// ForceFullBackup=true. The new checkpoint replaces the old one in BSL.
 	AnnotationForceFullBackup = "kubevirt-datamover.io/force-full-backup"
 
+	// AnnotationBackupPVCSize, when set on a DataUpload, overrides the
+	// calculated temp PVC size. Value must be a valid Kubernetes quantity
+	// (e.g., "50Gi").
+	AnnotationBackupPVCSize = "kubevirt-datamover.io/backup-pvc-size"
+
 	// AnnotationDataUploadName is the annotation key for the DataUpload name.
 	// Used on VMB, VMBT, and PVC resources to track ownership.
 	AnnotationDataUploadName = "velero.io/dataupload-name"


### PR DESCRIPTION
## Summary

- **VMB failure detection**: `evaluateVMBackupStatus` treated `Done=True` as unconditional success, but KubeVirt sets `Done=True + Reason=Failed` when backup fails (e.g., "No space left on device"). The controller would proceed to launch the datamover pod which found no qcow2 files. Now checks `Progressing` condition for `Reason=Failed` before declaring success.
- **Dynamic PVC sizing** (closes #5): Replaces hardcoded 10Gi temp PVC with source PVC capacity + 20% overhead (for filesystem overhead and qcow2 metadata). Supports user override via annotation `kubevirt-datamover.io/backup-pvc-size`.

## Test plan

- [x] New test: `VMB Done True with Failed reason transitions to Failed`
- [x] New test: `TestAddOverhead` — 4 cases for overhead calculation
- [x] New test: `TestCalculateBackupPVCSize` — 7 cases (source PVC sizing, annotation override, invalid annotation, missing PVC, no source PVC, min floor, cross-namespace)
- [x] All existing tests pass (`go test ./...`)
- [x] Deploy with test image and verify:
  - Backup of VM with disk > 10Gi creates appropriately sized temp PVC (source + 20%)
  - VMB failure correctly transitions DataUpload to Failed
  - User override annotation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of terminal failures for backup operations so failed backups are logged and halted promptly.

* **New Features**
  * Allow explicit temporary storage sizing via annotation.
  * Temporary backup storage now auto-sizes from source capacity (supports multi-disk aggregation), applies overhead and a minimum, and logs the computed size.

* **Tests**
  * Added unit tests covering failure handling and various sizing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->