### PR TITLE
fix: replace custom AWS credential parser with SDK's built-in parser

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -96,7 +96,11 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-        volumeMounts: []
-      volumes: []
+        volumeMounts:
+          - name: tmp
+            mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.25.8
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/evanphx/json-patch/v5 v5.9.11
@@ -31,6 +30,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.7 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect

--- a/pkg/uploader/objectstore.go
+++ b/pkg/uploader/objectstore.go
@@ -29,7 +29,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -48,10 +47,11 @@ type S3ObjectStore struct {
 }
 
 // NewS3ObjectStore creates a new S3ObjectStore.
-// credentialsData contains the raw credential file content (INI-style with
-// aws_access_key_id and aws_secret_access_key). Pass nil to use default
-// AWS credential chain (env vars, instance profile, etc.).
-func NewS3ObjectStore(bucket, prefix, region string, credentialsData []byte) (*S3ObjectStore, error) {
+// credentialsFile is the path to an AWS credentials file (INI-style).
+// Pass empty string to use the default AWS credential chain (env vars,
+// instance profile, etc.). The file is parsed by the AWS SDK which handles
+// quoted values, profiles, session tokens, and role assumption.
+func NewS3ObjectStore(bucket, prefix, region, credentialsFile string) (*S3ObjectStore, error) {
 	store := &S3ObjectStore{
 		bucket: bucket,
 		prefix: prefix,
@@ -62,8 +62,8 @@ func NewS3ObjectStore(bucket, prefix, region string, credentialsData []byte) (*S
 		"prefix": prefix,
 		"region": region,
 	}
-	if len(credentialsData) > 0 {
-		configMap["credentialsData"] = string(credentialsData)
+	if credentialsFile != "" {
+		configMap["credentialsFile"] = credentialsFile
 	}
 
 	if err := store.Init(configMap); err != nil {
@@ -75,8 +75,10 @@ func NewS3ObjectStore(bucket, prefix, region string, credentialsData []byte) (*S
 
 // Init initializes the ObjectStore with the provided config.
 // This implements velero.ObjectStore.Init().
-// Expected config keys: bucket, prefix, region, and either credentialsData
-// (raw credential content) or credentialsFile (path to credentials file).
+// Expected config keys: bucket, prefix, region, and optionally credentialsFile
+// (path to credentials file) or credentialsData (raw credential content that
+// will be written to a temp file). Credential parsing is delegated to the AWS
+// SDK via config.WithSharedCredentialsFiles, matching Velero's approach.
 func (s *S3ObjectStore) Init(configMap map[string]string) error {
 	bucket := configMap["bucket"]
 	prefix := configMap["prefix"]
@@ -98,19 +100,25 @@ func (s *S3ObjectStore) Init(configMap map[string]string) error {
 		opts = append(opts, config.WithRegion(region))
 	}
 
-	// Load credentials: prefer in-memory data, fall back to file path
-	if credData := configMap["credentialsData"]; credData != "" {
-		creds, err := ParseAWSCredentials([]byte(credData))
+	// Load credentials using the AWS SDK's built-in parser, matching Velero's
+	// pattern (velero/pkg/repository/config/aws.go). This correctly handles
+	// quoted values, named profiles, session tokens, and role assumption.
+	if credFile := configMap["credentialsFile"]; credFile != "" {
+		opts = append(opts,
+			config.WithSharedCredentialsFiles([]string{credFile}),
+			config.WithSharedConfigFiles([]string{credFile}),
+		)
+	} else if credData := configMap["credentialsData"]; credData != "" {
+		// Write in-memory credentials to a temp file for the AWS SDK to parse.
+		tmpFile, err := writeCredentialsToTempFile([]byte(credData))
 		if err != nil {
-			return fmt.Errorf("failed to parse credentials: %w", err)
+			return fmt.Errorf("failed to write credentials to temp file: %w", err)
 		}
-		opts = append(opts, config.WithCredentialsProvider(creds))
-	} else if credFile := configMap["credentialsFile"]; credFile != "" {
-		creds, err := loadAWSCredentialsFromFile(credFile)
-		if err != nil {
-			return fmt.Errorf("failed to load credentials: %w", err)
-		}
-		opts = append(opts, config.WithCredentialsProvider(creds))
+		defer func() { _ = os.Remove(tmpFile) }()
+		opts = append(opts,
+			config.WithSharedCredentialsFiles([]string{tmpFile}),
+			config.WithSharedConfigFiles([]string{tmpFile}),
+		)
 	}
 
 	// Add retry configuration for transient errors
@@ -298,71 +306,56 @@ func (s *S3ObjectStore) GetObjectBytes(key string) ([]byte, error) {
 	return io.ReadAll(reader)
 }
 
-// ParseAWSCredentials parses AWS credentials from raw INI-style content.
-// The expected format contains aws_access_key_id and aws_secret_access_key
-// key=value pairs (with optional [default] section header).
-func ParseAWSCredentials(data []byte) (aws.CredentialsProvider, error) {
-	var accessKeyID, secretAccessKey string
-
-	for line := range strings.SplitSeq(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "aws_access_key_id") {
-			parts := strings.SplitN(line, "=", 2)
-			if len(parts) == 2 {
-				accessKeyID = strings.TrimSpace(parts[1])
-			}
-		} else if strings.HasPrefix(line, "aws_secret_access_key") {
-			parts := strings.SplitN(line, "=", 2)
-			if len(parts) == 2 {
-				secretAccessKey = strings.TrimSpace(parts[1])
-			}
-		}
-	}
-
-	if accessKeyID == "" || secretAccessKey == "" {
-		return nil, fmt.Errorf(
-			"credentials data missing aws_access_key_id or aws_secret_access_key",
-		)
-	}
-
-	return credentials.NewStaticCredentialsProvider(
-		accessKeyID, secretAccessKey, "",
-	), nil
-}
-
-// loadAWSCredentialsFromFile loads AWS credentials from a file path.
-// Used by the datamover pod where credentials are mounted as a volume.
-func loadAWSCredentialsFromFile(path string) (aws.CredentialsProvider, error) {
-	data, err := os.ReadFile(path)
+// writeCredentialsToTempFile writes credential data to a temporary file and returns
+// the file path. The caller is responsible for removing the file when done.
+// The file is created with restrictive permissions (0600) to protect credentials.
+func writeCredentialsToTempFile(data []byte) (string, error) {
+	tmpFile, err := os.CreateTemp("", "aws-credentials-*")
 	if err != nil {
-		return nil, fmt.Errorf("failed to read credentials file: %w", err)
+		return "", fmt.Errorf("failed to create temp credentials file: %w", err)
 	}
-	return ParseAWSCredentials(data)
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("failed to write temp credentials file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("failed to close temp credentials file: %w", err)
+	}
+
+	return tmpFile.Name(), nil
 }
 
 // InitObjectStore creates an ObjectStore based on the provider type.
-// If CredentialsData is set, it is used directly. Otherwise, CredentialsFile
-// is read from disk (used by the datamover pod where credentials are volume-mounted).
+// Credentials are resolved to a file path for the AWS SDK's built-in parser:
+// - If CredentialsData is set, it is written to a temp file.
+// - If CredentialsFile is set, the path is used directly.
 func InitObjectStore(cfg *UploaderConfig) (velero.ObjectStore, error) {
 	if cfg.BSLProvider == "" {
 		return nil, fmt.Errorf("BSL provider is required but was empty")
 	}
 
-	// Resolve credentials: prefer in-memory data, fall back to reading file
-	credData := cfg.CredentialsData
-	if len(credData) == 0 && cfg.CredentialsFile != "" {
-		var err error
-		credData, err = os.ReadFile(cfg.CredentialsFile)
+	// Resolve credentials to a file path for the AWS SDK.
+	// Prefer in-memory data (controller path), fall back to file (uploader pod path).
+	credentialsFile := ""
+	if len(cfg.CredentialsData) > 0 {
+		tmpFile, err := writeCredentialsToTempFile(cfg.CredentialsData)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read credentials file %s: %w",
-				cfg.CredentialsFile, err)
+			return nil, fmt.Errorf("failed to write credentials: %w", err)
 		}
+		defer func() { _ = os.Remove(tmpFile) }()
+		credentialsFile = tmpFile
+	} else if cfg.CredentialsFile != "" {
+		credentialsFile = cfg.CredentialsFile
 	}
 
 	switch strings.ToLower(cfg.BSLProvider) {
 	case "aws":
 		return NewS3ObjectStore(
-			cfg.BSLBucket, cfg.BSLPrefix, cfg.BSLRegion, credData,
+			cfg.BSLBucket, cfg.BSLPrefix, cfg.BSLRegion, credentialsFile,
 		)
 	case "gcp":
 		// TODO: Implement GCP Cloud Storage support (issue #11)
@@ -373,7 +366,7 @@ func InitObjectStore(cfg *UploaderConfig) (velero.ObjectStore, error) {
 	default:
 		// Try S3-compatible for unknown providers
 		return NewS3ObjectStore(
-			cfg.BSLBucket, cfg.BSLPrefix, cfg.BSLRegion, credData,
+			cfg.BSLBucket, cfg.BSLPrefix, cfg.BSLRegion, credentialsFile,
 		)
 	}
 }

--- a/pkg/uploader/objectstore_test.go
+++ b/pkg/uploader/objectstore_test.go
@@ -78,62 +78,90 @@ func TestS3ObjectStoreFullKey(t *testing.T) {
 	}
 }
 
-func TestParseAWSCredentials(t *testing.T) {
+func TestWriteCredentialsToTempFile(t *testing.T) {
+	content := "[default]\naws_access_key_id = AKID\naws_secret_access_key = SECRET\n"
+
+	path, err := writeCredentialsToTempFile([]byte(content))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = os.Remove(path) }()
+
+	// Verify file exists and contains expected content
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read temp file: %v", err)
+	}
+	if string(data) != content {
+		t.Errorf("temp file content = %q, want %q", string(data), content)
+	}
+
+	// Verify file has restrictive permissions
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("failed to stat temp file: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm&0o077 != 0 {
+		t.Errorf("temp file permissions = %o, want no group/other access", perm)
+	}
+}
+
+func TestInitWithSDKCredentials(t *testing.T) {
 	tests := []struct {
 		name        string
-		data        []byte
+		credContent string
 		expectError bool
 	}{
 		{
-			name: "valid credentials with section header",
-			data: []byte("[default]\n" +
+			name: "standard unquoted credentials",
+			credContent: "[default]\n" +
 				"aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n" +
-				"aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"),
+				"aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
 			expectError: false,
 		},
 		{
-			name: "valid credentials without section header",
-			data: []byte("aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n" +
-				"aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"),
+			name: "quoted credentials (the bug this fixes)",
+			credContent: "[default]\n" +
+				"aws_access_key_id = \"AKIAIOSFODNN7EXAMPLE\"\n" +
+				"aws_secret_access_key = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"\n",
 			expectError: false,
 		},
 		{
-			name: "valid credentials with extra whitespace",
-			data: []byte("\n" +
-				"  aws_access_key_id   =   AKIAIOSFODNN7EXAMPLE\n" +
-				"  aws_secret_access_key   =   wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n\n"),
+			name: "credentials with named profile",
+			credContent: "[profile backup]\n" +
+				"aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n" +
+				"aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
+			// SDK loads default profile; a non-default profile without AWS_PROFILE
+			// set means no credentials are found, but Init() still succeeds —
+			// the error would come at request time, not at config load time.
 			expectError: false,
 		},
 		{
-			name:        "missing access key id",
-			data:        []byte("aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
-			expectError: true,
-		},
-		{
-			name:        "missing secret access key",
-			data:        []byte("aws_access_key_id = AKIAIOSFODNN7EXAMPLE"),
-			expectError: true,
-		},
-		{
-			name:        "empty data",
-			data:        []byte(""),
-			expectError: true,
-		},
-		{
-			name:        "nil data",
-			data:        nil,
-			expectError: true,
-		},
-		{
-			name:        "empty values",
-			data:        []byte("aws_access_key_id =\naws_secret_access_key ="),
-			expectError: true,
+			name: "credentials with session token",
+			credContent: "[default]\n" +
+				"aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n" +
+				"aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n" +
+				"aws_session_token = FwoGZXIvYXdzEBYaDHqa0AP\n",
+			expectError: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			creds, err := ParseAWSCredentials(tt.data)
+			// Write credentials to a temp file
+			tmpDir := t.TempDir()
+			credFile := filepath.Join(tmpDir, "credentials")
+			if err := os.WriteFile(credFile, []byte(tt.credContent), 0600); err != nil {
+				t.Fatalf("failed to write credentials file: %v", err)
+			}
+
+			store := &S3ObjectStore{}
+			err := store.Init(map[string]string{
+				"bucket":          "test-bucket",
+				"region":          "us-east-1",
+				"credentialsFile": credFile,
+			})
 
 			if tt.expectError {
 				if err == nil {
@@ -143,36 +171,40 @@ func TestParseAWSCredentials(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
-				if creds == nil {
-					t.Error("expected credentials provider but got nil")
-				}
 			}
 		})
 	}
 }
 
-func TestLoadAWSCredentialsFromFile(t *testing.T) {
-	// Test that file-based loading still works (used by datamover pod)
-	tmpDir := t.TempDir()
-	tmpFile := filepath.Join(tmpDir, "credentials")
-	content := "[default]\naws_access_key_id = AKID\naws_secret_access_key = SECRET\n"
-	if err := os.WriteFile(tmpFile, []byte(content), 0600); err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
+func TestInitWithCredentialsData(t *testing.T) {
+	// Test the in-memory credentials path (controller uses this)
+	store := &S3ObjectStore{}
+	credData := "[default]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n" +
+		"aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"
 
-	creds, err := loadAWSCredentialsFromFile(tmpFile)
+	err := store.Init(map[string]string{
+		"bucket":          "test-bucket",
+		"region":          "us-east-1",
+		"credentialsData": credData,
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if creds == nil {
-		t.Error("expected credentials provider but got nil")
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 
-func TestLoadAWSCredentialsFromFileNotExists(t *testing.T) {
-	_, err := loadAWSCredentialsFromFile("/nonexistent/path/credentials")
-	if err == nil {
-		t.Error("expected error for non-existent file")
+func TestInitWithMissingCredentialsFile(t *testing.T) {
+	// The AWS SDK does not error when a credentials file is missing — it
+	// silently falls back to the default credential chain. Init() should
+	// succeed; authentication errors surface at request time.
+	store := &S3ObjectStore{}
+	err := store.Init(map[string]string{
+		"bucket":          "test-bucket",
+		"region":          "us-east-1",
+		"credentialsFile": "/nonexistent/path/credentials",
+	})
+	if err != nil {
+		t.Errorf("unexpected error: Init should succeed with missing cred file "+
+			"(SDK falls back to default chain): %v", err)
 	}
 }
 

--- a/pkg/uploader/objectstore_test.go
+++ b/pkg/uploader/objectstore_test.go
@@ -254,6 +254,55 @@ func TestS3ObjectStoreInit(t *testing.T) {
 	}
 }
 
+func TestInitObjectStoreWithCredentialsData(t *testing.T) {
+	tests := []struct {
+		name        string
+		credData    string
+		expectError bool
+	}{
+		{
+			name: "standard unquoted credentials",
+			credData: "[default]\n" +
+				"aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n" +
+				"aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
+			expectError: false,
+		},
+		{
+			name: "quoted credentials (the bug this fixes)",
+			credData: "[default]\n" +
+				"aws_access_key_id = \"AKIAIOSFODNN7EXAMPLE\"\n" +
+				"aws_secret_access_key = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"\n",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &UploaderConfig{
+				BSLProvider:     "aws",
+				BSLBucket:       "test-bucket",
+				BSLRegion:       "us-east-1",
+				CredentialsData: []byte(tt.credData),
+			}
+
+			store, err := InitObjectStore(cfg)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if store == nil {
+					t.Error("expected non-nil store")
+				}
+			}
+		})
+	}
+}
+
 func TestInitObjectStore(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

- Replaces the custom `ParseAWSCredentials()` INI parser with the AWS SDK's built-in credential loading via `config.WithSharedCredentialsFiles` / `config.WithSharedConfigFiles`, matching Velero's approach
- Fixes backup failures (`PartiallyFailed`) when BSL cloud-credentials secret contains quoted values (e.g., `aws_access_key_id = "AKID..."`)
- Adds `/tmp` emptyDir volume mount to controller pod for temp file creation on read-only root filesystems

Fixes: #22
Part of: #25

## Changes

| File | Change |
|------|--------|
| `pkg/uploader/objectstore.go` | Removed `ParseAWSCredentials()` and `loadAWSCredentialsFromFile()`. `Init()` now delegates to AWS SDK. Added `writeCredentialsToTempFile()` for controller's in-memory credential path. |
| `pkg/uploader/objectstore_test.go` | Replaced old parser tests with SDK integration tests covering: unquoted, quoted, named profile, session token credentials. Added end-to-end `InitObjectStore` tests for the `CredentialsData` path. |
| `config/manager/manager.yaml` | Added `/tmp` emptyDir volume mount (needed for `os.CreateTemp` on read-only root filesystem). |
| `go.mod` | Moved `aws-sdk-go-v2/credentials` from direct to indirect (no longer imported directly). |

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] Live cluster test 1: backup with **unquoted** credentials -- Completed (regression check)
- [x] Live cluster test 2: backup with **quoted** credentials -- Completed (bug fix validation)
- [x] Controller logs clean -- no credential errors in either test
- [x] Both tests used full KDM flow: Velero Backup -> DataUpload -> VMB/VMBT -> libvirt checkpoint -> qcow2 upload to S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated AWS credentials handling to use standard credential resolution mechanisms.

* **Tests**
  * Enhanced test coverage for credential loading and temporary file operations.

* **Chores**
  * Updated dependency classification in module configuration.
  * Added temporary volume to Kubernetes deployment pod specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->