### PR TITLE
Phase 0+1: DataDownload prerequisites and shared helper extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,11 @@ COPY pkg/ pkg/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# Use UBI9-minimal as base image to include qemu-img for VM disk restore.
+# qemu-img is required by the datamover download path to reconstruct qcow2
+# incremental chains into raw disk images (issue #73).
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN microdnf install -y qemu-img && microdnf clean all
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,11 @@ COPY pkg/ pkg/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-# Use UBI9 as base image to include qemu-img for VM disk restore.
+# Use CentOS Stream 9 as base image to include qemu-img for VM disk restore.
 # qemu-img is required by the datamover download path to reconstruct qcow2
 # incremental chains into raw disk images (issue #73).
-# UBI9-minimal lacks the appstream repo needed for qemu-img, so we use full UBI9.
-FROM registry.access.redhat.com/ubi9/ubi:latest
+# UBI9 repos do not include qemu-img; CentOS Stream 9 has it in AppStream.
+FROM quay.io/centos/centos:stream9
 RUN dnf install -y qemu-img && dnf clean all
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,12 @@ COPY pkg/ pkg/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-# Use UBI9-minimal as base image to include qemu-img for VM disk restore.
+# Use UBI9 as base image to include qemu-img for VM disk restore.
 # qemu-img is required by the datamover download path to reconstruct qcow2
 # incremental chains into raw disk images (issue #73).
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-RUN microdnf install -y qemu-img && microdnf clean all
+# UBI9-minimal lacks the appstream repo needed for qemu-img, so we use full UBI9.
+FROM registry.access.redhat.com/ubi9/ubi:latest
+RUN dnf install -y qemu-img && dnf clean all
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,15 @@ COPY pkg/ pkg/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-# Use CentOS Stream 9 as base image to include qemu-img for VM disk restore.
+# Use CentOS Stream 9 minimal as base image to include qemu-img for VM disk restore.
 # qemu-img is required by the datamover download path to reconstruct qcow2
 # incremental chains into raw disk images (issue #73).
 # UBI9 repos (BaseOS, AppStream, CodeReady) do not include qemu-img.
 # CentOS Stream 9 has it in AppStream. For downstream Konflux builds,
 # UBI9 + full RHEL repos work — see:
 # https://github.com/migtools/oadp-vm-file-restore/blob/oadp-dev/containers/oadp-vmfr-access/konflux.Dockerfile
-FROM quay.io/centos/centos:stream9
-RUN dnf install -y qemu-img && dnf clean all
+FROM quay.io/centos/centos:stream9-minimal
+RUN microdnf install -y qemu-img && microdnf clean all
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,10 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Use CentOS Stream 9 as base image to include qemu-img for VM disk restore.
 # qemu-img is required by the datamover download path to reconstruct qcow2
 # incremental chains into raw disk images (issue #73).
-# UBI9 repos do not include qemu-img; CentOS Stream 9 has it in AppStream.
+# UBI9 repos (BaseOS, AppStream, CodeReady) do not include qemu-img.
+# CentOS Stream 9 has it in AppStream. For downstream Konflux builds,
+# UBI9 + full RHEL repos work — see:
+# https://github.com/migtools/oadp-vm-file-restore/blob/oadp-dev/containers/oadp-vmfr-access/konflux.Dockerfile
 FROM quay.io/centos/centos:stream9
 RUN dnf install -y qemu-img && dnf clean all
 WORKDIR /

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -61,7 +61,7 @@ func findPodByUID(ctx context.Context, k8sClient client.Client, uidLabelKey, uid
 		return nil, nil
 	}
 	if len(podList.Items) > 1 {
-		return nil, fmt.Errorf("found multiple datamover pods for UID %s", uid)
+		return nil, fmt.Errorf("found multiple datamover pods in namespace %s with label %s=%s", namespace, uidLabelKey, uid)
 	}
 	return &podList.Items[0], nil
 }

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -98,6 +98,9 @@ func extractPodFailureMessage(pod *corev1.Pod) string {
 		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
 			return cs.State.Terminated.Message
 		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
+			return cs.State.Terminated.Reason
+		}
 	}
 
 	for _, cond := range pod.Status.Conditions {

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/migtools/kubevirt-datamover-controller/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"context"
+
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+)
+
+// getBackupStorageLocation fetches the BSL by name from the OADP namespace,
+// falling back to fallbackNamespace if oadpNamespace is empty.
+func getBackupStorageLocation(ctx context.Context, k8sClient client.Client, bslName, oadpNamespace, fallbackNamespace string) (*velerov1.BackupStorageLocation, error) {
+	if bslName == "" {
+		return nil, fmt.Errorf("no BackupStorageLocation name specified")
+	}
+
+	namespace := oadpNamespace
+	if namespace == "" {
+		namespace = fallbackNamespace
+	}
+
+	bsl := &velerov1.BackupStorageLocation{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: bslName, Namespace: namespace}, bsl); err != nil {
+		return nil, fmt.Errorf("failed to get BackupStorageLocation %s/%s: %w", namespace, bslName, err)
+	}
+
+	return bsl, nil
+}
+
+// findPodByUID finds the unique datamover pod associated with a resource UID.
+func findPodByUID(ctx context.Context, k8sClient client.Client, uidLabelKey, uid, namespace string) (*corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{uidLabelKey: uid}); err != nil {
+		return nil, err
+	}
+	if len(podList.Items) == 0 {
+		return nil, nil
+	}
+	if len(podList.Items) > 1 {
+		return nil, fmt.Errorf("found multiple datamover pods for UID %s", uid)
+	}
+	return &podList.Items[0], nil
+}
+
+// cleanupPodsByUID deletes all pods matching a UID label in the given namespace.
+func cleanupPodsByUID(ctx context.Context, k8sClient client.Client, uidLabelKey, uid, namespace string, logger logr.Logger) {
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{uidLabelKey: uid}); err != nil {
+		logger.Error(err, "Failed to list datamover pods for cleanup")
+		return
+	}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if err := k8sClient.Delete(ctx, pod); err != nil && !errors.IsNotFound(err) {
+			logger.Error(err, "Failed to delete datamover pod", "pod", pod.Name)
+		} else {
+			logger.Info("Deleted datamover pod", "pod", pod.Name)
+		}
+	}
+}
+
+// extractPodFailureMessage extracts the failure message from a failed pod.
+func extractPodFailureMessage(pod *corev1.Pod) string {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
+			return cs.State.Terminated.Message
+		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
+			return cs.State.Terminated.Reason
+		}
+	}
+
+	for _, cs := range pod.Status.InitContainerStatuses {
+		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
+			return cs.State.Terminated.Message
+		}
+	}
+
+	for _, cond := range pod.Status.Conditions {
+		if cond.Status == corev1.ConditionFalse && cond.Message != "" {
+			return cond.Message
+		}
+	}
+
+	return "unknown error"
+}
+
+// safeGenerateNamePrefix truncates a GenerateName prefix so that the final
+// name (prefix + 5 random chars) does not exceed maxNameLen.
+func safeGenerateNamePrefix(prefix string, maxNameLen int) string {
+	maxPrefix := max(maxNameLen-k8sGenerateNameRandomLen, 1)
+	if len(prefix) > maxPrefix {
+		prefix = prefix[:maxPrefix]
+	}
+	return prefix
+}
+
+// addOverhead returns qty increased by the given percentage.
+// For example, addOverhead(30Gi, 20) returns 36Gi.
+func addOverhead(qty resource.Quantity, percent int64) resource.Quantity {
+	base := qty.Value()
+	overhead := base * percent / 100
+	result := resource.NewQuantity(base+overhead, resource.BinarySI)
+	return *result
+}
+
+// getVeleroBackupName extracts the Velero backup name from resource labels.
+func getVeleroBackupName(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	return labels[common.LabelVeleroBackupName]
+}

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -17,19 +17,18 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/migtools/kubevirt-datamover-controller/pkg/common"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"context"
-
-	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/migtools/kubevirt-datamover-controller/pkg/common"
 )
 
 // getBackupStorageLocation fetches the BSL by name from the OADP namespace,

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -1389,7 +1389,11 @@ func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logge
 // getBackupStorageLocationForDU is a convenience wrapper around getBackupStorageLocation
 // that extracts the BSL name from a DataUpload.
 func (r *KubeVirtDataUploadReconciler) getBackupStorageLocationForDU(ctx context.Context, du *velerov2alpha1.DataUpload) (*velerov1.BackupStorageLocation, error) {
-	return getBackupStorageLocation(ctx, r.Client, du.Spec.BackupStorageLocation, r.OADPNamespace, du.Namespace)
+	bsl, err := getBackupStorageLocation(ctx, r.Client, du.Spec.BackupStorageLocation, r.OADPNamespace, du.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("DataUpload %s/%s: %w", du.Namespace, du.Name, err)
+	}
+	return bsl, nil
 }
 
 // findVMBForDataUpload finds the unique VirtualMachineBackup associated with a DataUpload.

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -254,7 +254,7 @@ func (r *KubeVirtDataUploadReconciler) handleAccepted(ctx context.Context, logge
 	// BSL must be in Available phase — if it's not, fail immediately rather than
 	// creating resources (PVC, VMBT, VMB) that will be wasted.
 	if du.Spec.BackupStorageLocation != "" {
-		bslObj, err := r.getBackupStorageLocation(ctx, du)
+		bslObj, err := r.getBackupStorageLocationForDU(ctx, du)
 		if err != nil {
 			logger.Error(err, "BackupStorageLocation not accessible")
 			if updateErr := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
@@ -574,7 +574,7 @@ func (r *KubeVirtDataUploadReconciler) validateBSLCheckpoint(ctx context.Context
 	forceFullBackup := false
 
 	var checkpointLookup *uploader.CheckpointLookupResult
-	bsl, bslErr := r.getBackupStorageLocation(ctx, du)
+	bsl, bslErr := r.getBackupStorageLocationForDU(ctx, du)
 	if bslErr != nil {
 		// BSL lookup failure is non-fatal. Validation will be retried on the
 		// next reconcile.
@@ -676,7 +676,7 @@ func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logge
 	// This prevents leaving PV in a bad state if these checks fail
 
 	// Get BackupStorageLocation
-	bsl, err := r.getBackupStorageLocation(ctx, du)
+	bsl, err := r.getBackupStorageLocationForDU(ctx, du)
 	if err != nil {
 		logger.Error(err, "Failed to get BackupStorageLocation")
 		if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed, fmt.Sprintf("Failed to get BSL: %v", err)); err != nil {
@@ -725,7 +725,7 @@ func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logge
 			"sourceNamespace", vmRef.Namespace,
 			"targetNamespace", podNamespace)
 
-		rebindResult, err := r.rebindPVToNamespace(ctx, logger, sourcePVCName, vmRef.Namespace, podNamespace, du.Name, string(du.UID))
+		rebindResult, err := rebindPVToNamespace(ctx, r.Client, logger, sourcePVCName, vmRef.Namespace, podNamespace, du.Name, string(du.UID))
 		if err != nil {
 			// Fail without retry: PV rebind is a multi-step operation (delete PVC, patch PV, create new PVC).
 			// If it fails partway through, automatic retries could leave resources in an inconsistent state.
@@ -877,24 +877,10 @@ func (r *KubeVirtDataUploadReconciler) handleInProgress(ctx context.Context, log
 
 // cleanupDatamoverResources cleans up resources created during the datamover process
 func (r *KubeVirtDataUploadReconciler) cleanupDatamoverResources(ctx context.Context, logger logr.Logger, du *velerov2alpha1.DataUpload, podNamespace string) {
-	// Delete the datamover pod
-	podList := &corev1.PodList{}
-	if err := r.List(ctx, podList, client.InNamespace(podNamespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
-		logger.Error(err, "Failed to list datamover pods for cleanup")
-	} else {
-		for i := range podList.Items {
-			pod := &podList.Items[i]
-			if err := r.Delete(ctx, pod); err != nil && !errors.IsNotFound(err) {
-				logger.Error(err, "Failed to delete datamover pod", "pod", pod.Name)
-			} else {
-				logger.Info("Deleted datamover pod", "pod", pod.Name)
-			}
-		}
-	}
+	cleanupPodsByUID(ctx, r.Client, common.LabelDataUploadUID, string(du.UID), podNamespace, logger)
 
-	// Delete the rebound PVC and PV
 	reboundPVCName := common.SafeResourceName(common.ReboundPVCNamePrefix, du.Name)
-	if err := r.cleanupReboundPVCAndPV(ctx, logger, reboundPVCName, podNamespace, string(du.UID)); err != nil {
+	if err := cleanupReboundPVCAndPV(ctx, r.Client, logger, reboundPVCName, podNamespace, string(du.UID)); err != nil {
 		logger.Error(err, "Failed to cleanup rebound PVC and PV", "pvc", reboundPVCName)
 		// Continue - don't block completion on cleanup failures
 	}
@@ -1192,15 +1178,6 @@ func (r *KubeVirtDataUploadReconciler) calculateBackupPVCSize(ctx context.Contex
 	return defaultSize, nil
 }
 
-// addOverhead returns qty increased by the given percentage.
-// For example, addOverhead(30Gi, 20) returns 36Gi.
-func addOverhead(qty resource.Quantity, percent int64) resource.Quantity {
-	base := qty.Value()
-	overhead := base * percent / 100
-	result := resource.NewQuantity(base+overhead, resource.BinarySI)
-	return *result
-}
-
 // prepareVMBackupTracker returns an existing on-cluster VirtualMachineBackupTracker
 // for the VM if one exists, or creates a new one (restoring LatestCheckpoint from
 // S3 if available). The VMBT is left on-cluster between backups so KubeVirt can
@@ -1226,7 +1203,7 @@ func (r *KubeVirtDataUploadReconciler) prepareVMBackupTracker(ctx context.Contex
 	// This is non-fatal: if BSL is unreachable or no VMBT exists yet (first backup),
 	// we create a fresh VMBT without a checkpoint.
 	var archivedVMBT *kubevirtbackupv1alpha1.VirtualMachineBackupTracker
-	bsl, bslErr := r.getBackupStorageLocation(ctx, du)
+	bsl, bslErr := r.getBackupStorageLocationForDU(ctx, du)
 	if bslErr != nil {
 		logger.Info("BSL not available for VMBT lookup, creating fresh VMBT",
 			"reason", bslErr.Error())
@@ -1409,26 +1386,10 @@ func (r *KubeVirtDataUploadReconciler) ensureVMBackup(ctx context.Context, logge
 	return vmb, true, nil
 }
 
-// getBackupStorageLocation fetches the BSL referenced by the DataUpload
-func (r *KubeVirtDataUploadReconciler) getBackupStorageLocation(ctx context.Context, du *velerov2alpha1.DataUpload) (*velerov1.BackupStorageLocation, error) {
-	bslName := du.Spec.BackupStorageLocation
-	if bslName == "" {
-		return nil, fmt.Errorf("DataUpload %s has no BackupStorageLocation specified", du.Name)
-	}
-
-	// BSL is in the OADP namespace (where Velero runs)
-	namespace := r.OADPNamespace
-	if namespace == "" {
-		// Fall back to the DataUpload's namespace
-		namespace = du.Namespace
-	}
-
-	bsl := &velerov1.BackupStorageLocation{}
-	if err := r.Get(ctx, types.NamespacedName{Name: bslName, Namespace: namespace}, bsl); err != nil {
-		return nil, fmt.Errorf("failed to get BackupStorageLocation %s/%s: %w", namespace, bslName, err)
-	}
-
-	return bsl, nil
+// getBackupStorageLocationForDU is a convenience wrapper around getBackupStorageLocation
+// that extracts the BSL name from a DataUpload.
+func (r *KubeVirtDataUploadReconciler) getBackupStorageLocationForDU(ctx context.Context, du *velerov2alpha1.DataUpload) (*velerov1.BackupStorageLocation, error) {
+	return getBackupStorageLocation(ctx, r.Client, du.Spec.BackupStorageLocation, r.OADPNamespace, du.Namespace)
 }
 
 // findVMBForDataUpload finds the unique VirtualMachineBackup associated with a DataUpload.
@@ -1533,24 +1494,6 @@ func (r *KubeVirtDataUploadReconciler) hasOlderActiveDUForVM(ctx context.Context
 	return false, "", nil
 }
 
-// getVeleroBackupName extracts the Velero backup name from DataUpload labels
-func getVeleroBackupName(du *velerov2alpha1.DataUpload) string {
-	if du.Labels == nil {
-		return ""
-	}
-	return du.Labels[common.LabelVeleroBackupName]
-}
-
-// safeGenerateNamePrefix truncates a GenerateName prefix so that the final
-// name (prefix + 5 random chars) does not exceed maxNameLen.
-func safeGenerateNamePrefix(prefix string, maxNameLen int) string {
-	maxPrefix := max(maxNameLen-k8sGenerateNameRandomLen, 1)
-	if len(prefix) > maxPrefix {
-		prefix = prefix[:maxPrefix]
-	}
-	return prefix
-}
-
 // buildDatamoverPodConfig assembles the configuration for the datamover pod
 func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 	du *velerov2alpha1.DataUpload,
@@ -1582,6 +1525,7 @@ func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 	}
 
 	return &DatamoverPodConfig{
+		OperationMode:            OperationModeUpload,
 		Name:                     du.Name, // Used as a prefix for GenerateName
 		Namespace:                vmRef.Namespace,
 		Image:                    image,
@@ -1600,7 +1544,7 @@ func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 		VMNamespace:              vmRef.Namespace,
 		CheckpointName:           checkpointName,
 		BackupType:               backupType,
-		VeleroBackupName:         getVeleroBackupName(du),
+		VeleroBackupName:         getVeleroBackupName(du.Labels),
 		DataUploadName:           du.Name,
 		DataUploadUID:            string(du.UID),
 		VMBName:                  vmb.Name,
@@ -1608,35 +1552,6 @@ func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 		SourcePVCName:            "", // overridden by handlePrepared with the rebound PVC name
 		Labels:                   make(map[string]string),
 	}, nil
-}
-
-// extractPodFailureMessage extracts the failure message from a failed pod
-func extractPodFailureMessage(pod *corev1.Pod) string {
-	// Check container statuses for termination message
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
-			return cs.State.Terminated.Message
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
-			return cs.State.Terminated.Reason
-		}
-	}
-
-	// Check init container statuses
-	for _, cs := range pod.Status.InitContainerStatuses {
-		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
-			return cs.State.Terminated.Message
-		}
-	}
-
-	// Fall back to pod conditions
-	for _, cond := range pod.Status.Conditions {
-		if cond.Status == corev1.ConditionFalse && cond.Message != "" {
-			return cond.Message
-		}
-	}
-
-	return "unknown error"
 }
 
 // lookupCheckpointFromBSL reads the VM's checkpoint index from the BSL and returns
@@ -1658,15 +1573,5 @@ func (r *KubeVirtDataUploadReconciler) lookupCheckpointFromBSL(ctx context.Conte
 
 // findPodForDataUpload finds the unique datamover pod associated with a DataUpload.
 func (r *KubeVirtDataUploadReconciler) findPodForDataUpload(ctx context.Context, du *velerov2alpha1.DataUpload, namespace string) (*corev1.Pod, error) {
-	podList := &corev1.PodList{}
-	if err := r.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{common.LabelDataUploadUID: string(du.UID)}); err != nil {
-		return nil, err
-	}
-	if len(podList.Items) == 0 {
-		return nil, nil
-	}
-	if len(podList.Items) > 1 {
-		return nil, fmt.Errorf("found multiple datamover pods for DataUpload %s", du.Name)
-	}
-	return &podList.Items[0], nil
+	return findPodByUID(ctx, r.Client, common.LabelDataUploadUID, string(du.UID), namespace)
 }

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -725,7 +725,7 @@ func (r *KubeVirtDataUploadReconciler) handlePrepared(ctx context.Context, logge
 			"sourceNamespace", vmRef.Namespace,
 			"targetNamespace", podNamespace)
 
-		rebindResult, err := rebindPVToNamespace(ctx, r.Client, logger, sourcePVCName, vmRef.Namespace, podNamespace, du.Name, string(du.UID))
+		rebindResult, err := rebindPVToNamespace(ctx, r.Client, logger, sourcePVCName, vmRef.Namespace, podNamespace, du.Name, string(du.UID), common.LabelDataUploadUID, common.AnnotationDataUploadName)
 		if err != nil {
 			// Fail without retry: PV rebind is a multi-step operation (delete PVC, patch PV, create new PVC).
 			// If it fails partway through, automatic retries could leave resources in an inconsistent state.
@@ -880,7 +880,7 @@ func (r *KubeVirtDataUploadReconciler) cleanupDatamoverResources(ctx context.Con
 	cleanupPodsByUID(ctx, r.Client, common.LabelDataUploadUID, string(du.UID), podNamespace, logger)
 
 	reboundPVCName := common.SafeResourceName(common.ReboundPVCNamePrefix, du.Name)
-	if err := cleanupReboundPVCAndPV(ctx, r.Client, logger, reboundPVCName, podNamespace, string(du.UID)); err != nil {
+	if err := cleanupReboundPVCAndPV(ctx, r.Client, logger, reboundPVCName, podNamespace, string(du.UID), common.LabelDataUploadUID); err != nil {
 		logger.Error(err, "Failed to cleanup rebound PVC and PV", "pvc", reboundPVCName)
 		// Continue - don't block completion on cleanup failures
 	}
@@ -1545,8 +1545,10 @@ func (r *KubeVirtDataUploadReconciler) buildDatamoverPodConfig(
 		CheckpointName:           checkpointName,
 		BackupType:               backupType,
 		VeleroBackupName:         getVeleroBackupName(du.Labels),
-		DataUploadName:           du.Name,
-		DataUploadUID:            string(du.UID),
+		ResourceName:             du.Name,
+		ResourceUID:              string(du.UID),
+		UIDLabelKey:              common.LabelDataUploadUID,
+		NameAnnotationKey:        common.AnnotationDataUploadName,
 		VMBName:                  vmb.Name,
 		VMBTName:                 vmbtName,
 		SourcePVCName:            "", // overridden by handlePrepared with the rebound PVC name

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -2077,7 +2077,7 @@ func TestGetVeleroBackupName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := getVeleroBackupName(tt.du)
+			result := getVeleroBackupName(tt.du.Labels)
 			if result != tt.expected {
 				t.Errorf("getVeleroBackupName() = %q, want %q", result, tt.expected)
 			}
@@ -2410,7 +2410,7 @@ func TestGetBackupStorageLocation(t *testing.T) {
 			},
 			bsl:           nil,
 			expectError:   true,
-			errorContains: "no BackupStorageLocation specified",
+			errorContains: "no BackupStorageLocation name specified",
 		},
 	}
 
@@ -2427,7 +2427,7 @@ func TestGetBackupStorageLocation(t *testing.T) {
 				OADPNamespace: "openshift-adp",
 			}
 
-			bsl, err := r.getBackupStorageLocation(context.Background(), tt.du)
+			bsl, err := r.getBackupStorageLocationForDU(context.Background(), tt.du)
 
 			if tt.expectError {
 				if err == nil {

--- a/internal/controller/pod_builder.go
+++ b/internal/controller/pod_builder.go
@@ -25,8 +25,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// OperationMode determines whether the datamover pod runs upload or download.
+type OperationMode string
+
+const (
+	// OperationModeUpload runs the backup upload path.
+	OperationModeUpload OperationMode = "upload"
+
+	// OperationModeDownload runs the restore download path.
+	OperationModeDownload OperationMode = "download"
+)
+
 // DatamoverPodConfig contains configuration for building a datamover pod.
 type DatamoverPodConfig struct {
+	// OperationMode selects upload or download. Defaults to upload.
+	OperationMode OperationMode
+
 	// Pod identity
 	Name      string
 	Namespace string
@@ -73,10 +87,15 @@ type DatamoverPodConfig struct {
 
 // buildDatamoverPod creates a Pod spec for the datamover.
 func buildDatamoverPod(config *DatamoverPodConfig) *corev1.Pod {
+	mode := config.OperationMode
+	if mode == "" {
+		mode = OperationModeUpload
+	}
+
 	// Merge default labels with provided labels.
 	// Use UID for labels (always ≤ 63 chars); name goes in annotations.
 	labels := map[string]string{
-		common.LabelDatamoverPod:  "uploader",
+		common.LabelDatamoverPod:  string(mode),
 		common.LabelDataUploadUID: config.DataUploadUID,
 	}
 	maps.Copy(labels, config.Labels)
@@ -137,10 +156,10 @@ func buildDatamoverPod(config *DatamoverPodConfig) *corev1.Pod {
 			},
 			Containers: []corev1.Container{
 				{
-					Name:            "uploader",
+					Name:            string(mode),
 					Image:           config.Image,
 					ImagePullPolicy: config.ImagePullPolicy,
-					Command:         []string{"/manager", "upload"},
+					Command:         []string{"/manager", string(mode)},
 					Env:             envVars,
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/internal/controller/pod_builder.go
+++ b/internal/controller/pod_builder.go
@@ -30,10 +30,10 @@ type OperationMode string
 
 const (
 	// OperationModeUpload runs the backup upload path.
-	OperationModeUpload OperationMode = "upload"
+	OperationModeUpload OperationMode = OperationMode(common.PodTypeUpload)
 
 	// OperationModeDownload runs the restore download path.
-	OperationModeDownload OperationMode = "download"
+	OperationModeDownload OperationMode = OperationMode(common.PodTypeDownload)
 )
 
 // DatamoverPodConfig contains configuration for building a datamover pod.
@@ -73,10 +73,15 @@ type DatamoverPodConfig struct {
 	CheckpointName   string
 	BackupType       string
 	VeleroBackupName string
-	DataUploadName   string
-	DataUploadUID    string
+	ResourceName     string
+	ResourceUID      string
 	VMBName          string
 	VMBTName         string
+
+	// Identity label/annotation keys for the owning resource (DataUpload or DataDownload).
+	// These determine which label key carries the UID and which annotation carries the name.
+	UIDLabelKey       string
+	NameAnnotationKey string
 
 	// Source PVC
 	SourcePVCName string
@@ -94,14 +99,23 @@ func buildDatamoverPod(config *DatamoverPodConfig) *corev1.Pod {
 
 	// Merge default labels with provided labels.
 	// Use UID for labels (always ≤ 63 chars); name goes in annotations.
+	uidLabelKey := config.UIDLabelKey
+	if uidLabelKey == "" {
+		uidLabelKey = common.LabelDataUploadUID
+	}
+	nameAnnotationKey := config.NameAnnotationKey
+	if nameAnnotationKey == "" {
+		nameAnnotationKey = common.AnnotationDataUploadName
+	}
+
 	labels := map[string]string{
-		common.LabelDatamoverPod:  string(mode),
-		common.LabelDataUploadUID: config.DataUploadUID,
+		common.LabelDatamoverPod: string(mode),
+		uidLabelKey:              config.ResourceUID,
 	}
 	maps.Copy(labels, config.Labels)
 
 	annotations := map[string]string{
-		common.AnnotationDataUploadName: config.DataUploadName,
+		nameAnnotationKey: config.ResourceName,
 	}
 
 	// Build environment variables
@@ -121,8 +135,8 @@ func buildDatamoverPod(config *DatamoverPodConfig) *corev1.Pod {
 		{Name: uploader.EnvBackupType, Value: config.BackupType},
 		{Name: uploader.EnvVeleroBackupName, Value: config.VeleroBackupName},
 		{Name: uploader.EnvSourcePVCPath, Value: uploader.DefaultSourcePVCPath},
-		{Name: uploader.EnvDataUploadName, Value: config.DataUploadName},
-		{Name: uploader.EnvDataUploadUID, Value: config.DataUploadUID},
+		{Name: uploader.EnvDataUploadName, Value: config.ResourceName},
+		{Name: uploader.EnvDataUploadUID, Value: config.ResourceUID},
 		{Name: uploader.EnvVMBName, Value: config.VMBName},
 		{Name: uploader.EnvVMBTName, Value: config.VMBTName},
 	}

--- a/internal/controller/pod_builder_test.go
+++ b/internal/controller/pod_builder_test.go
@@ -104,15 +104,18 @@ func TestBuildDatamoverPod(t *testing.T) {
 		{
 			name: "download mode sets correct label, container name, and command",
 			config: &DatamoverPodConfig{
-				OperationMode:     OperationModeDownload,
-				Name:              "test-dl",
-				Namespace:         "test-ns",
-				Image:             "quay.io/test/datamover:latest",
-				ImagePullPolicy:   corev1.PullAlways,
-				ResourceName:      "test-dd",
-				ResourceUID:       "uid-dl-123",
-				UIDLabelKey:       common.LabelDataDownloadUID,
-				NameAnnotationKey: common.AnnotationDataDownloadName,
+				OperationMode:        OperationModeDownload,
+				Name:                 "test-dl",
+				Namespace:            "test-ns",
+				Image:                "quay.io/test/datamover:latest",
+				ImagePullPolicy:      corev1.PullAlways,
+				ResourceName:         "test-dd",
+				ResourceUID:          "uid-dl-123",
+				UIDLabelKey:          common.LabelDataDownloadUID,
+				NameAnnotationKey:    common.AnnotationDataDownloadName,
+				CredentialSecretName: "cloud-credentials",
+				CredentialSecretKey:  "cloud",
+				SourcePVCName:        "restore-scratch-pvc",
 			},
 			validate: func(t *testing.T, pod *corev1.Pod) {
 				if pod.Labels[common.LabelDatamoverPod] != "download" {

--- a/internal/controller/pod_builder_test.go
+++ b/internal/controller/pod_builder_test.go
@@ -50,8 +50,8 @@ func TestBuildDatamoverPod(t *testing.T) {
 				CheckpointName:       "checkpoint-001",
 				BackupType:           "full",
 				VeleroBackupName:     "backup-001",
-				DataUploadName:       "test-du",
-				DataUploadUID:        "uid-12345",
+				ResourceName:         "test-du",
+				ResourceUID:          "uid-12345",
 				VMBName:              "vmb-test-du",
 				SourcePVCName:        "kubevirt-backup-test-du",
 			},
@@ -102,6 +102,38 @@ func TestBuildDatamoverPod(t *testing.T) {
 			},
 		},
 		{
+			name: "download mode sets correct label, container name, and command",
+			config: &DatamoverPodConfig{
+				OperationMode:     OperationModeDownload,
+				Name:              "test-dl",
+				Namespace:         "test-ns",
+				Image:             "quay.io/test/datamover:latest",
+				ImagePullPolicy:   corev1.PullAlways,
+				ResourceName:      "test-dd",
+				ResourceUID:       "uid-dl-123",
+				UIDLabelKey:       common.LabelDataDownloadUID,
+				NameAnnotationKey: common.AnnotationDataDownloadName,
+			},
+			validate: func(t *testing.T, pod *corev1.Pod) {
+				if pod.Labels[common.LabelDatamoverPod] != "download" {
+					t.Errorf("label %s = %q, want %q", common.LabelDatamoverPod, pod.Labels[common.LabelDatamoverPod], "download")
+				}
+				if pod.Labels[common.LabelDataDownloadUID] != "uid-dl-123" {
+					t.Errorf("label %s = %q, want %q", common.LabelDataDownloadUID, pod.Labels[common.LabelDataDownloadUID], "uid-dl-123")
+				}
+				if pod.Annotations[common.AnnotationDataDownloadName] != "test-dd" {
+					t.Errorf("annotation %s = %q, want %q", common.AnnotationDataDownloadName, pod.Annotations[common.AnnotationDataDownloadName], "test-dd")
+				}
+				container := pod.Spec.Containers[0]
+				if container.Name != "download" {
+					t.Errorf("container name = %q, want %q", container.Name, "download")
+				}
+				if len(container.Command) != 2 || container.Command[0] != "/manager" || container.Command[1] != "download" {
+					t.Errorf("container command = %v, want [/manager download]", container.Command)
+				}
+			},
+		},
+		{
 			name: "environment variables are set correctly",
 			config: &DatamoverPodConfig{
 				Name:                     "test-pod",
@@ -122,8 +154,8 @@ func TestBuildDatamoverPod(t *testing.T) {
 				CheckpointName:           "cp-001",
 				BackupType:               "incremental",
 				VeleroBackupName:         "velero-backup",
-				DataUploadName:           "du-001",
-				DataUploadUID:            "uid-001",
+				ResourceName:             "du-001",
+				ResourceUID:              "uid-001",
 				VMBName:                  "vmb-001",
 				SourcePVCName:            "pvc-001",
 			},
@@ -279,8 +311,8 @@ func TestBuildDatamoverPod(t *testing.T) {
 				Name:                 "test-pod",
 				Namespace:            "default",
 				Image:                "test-image",
-				DataUploadName:       "du-001",
-				DataUploadUID:        "uid-001",
+				ResourceName:         "du-001",
+				ResourceUID:          "uid-001",
 				CredentialSecretName: "secret",
 				CredentialSecretKey:  "key",
 				SourcePVCName:        "pvc",

--- a/internal/controller/pod_builder_test.go
+++ b/internal/controller/pod_builder_test.go
@@ -65,8 +65,8 @@ func TestBuildDatamoverPod(t *testing.T) {
 				}
 
 				// Verify labels
-				if pod.Labels[common.LabelDatamoverPod] != "uploader" {
-					t.Errorf("label %s = %q, want %q", common.LabelDatamoverPod, pod.Labels[common.LabelDatamoverPod], "uploader")
+				if pod.Labels[common.LabelDatamoverPod] != "upload" {
+					t.Errorf("label %s = %q, want %q", common.LabelDatamoverPod, pod.Labels[common.LabelDatamoverPod], "upload")
 				}
 				if pod.Labels[common.LabelDataUploadUID] != "uid-12345" {
 					t.Errorf("label %s = %q, want %q", common.LabelDataUploadUID, pod.Labels[common.LabelDataUploadUID], "uid-12345")
@@ -88,8 +88,8 @@ func TestBuildDatamoverPod(t *testing.T) {
 					t.Fatalf("expected 1 container, got %d", len(pod.Spec.Containers))
 				}
 				container := pod.Spec.Containers[0]
-				if container.Name != "uploader" {
-					t.Errorf("container name = %q, want %q", container.Name, "uploader")
+				if container.Name != "upload" {
+					t.Errorf("container name = %q, want %q", container.Name, "upload")
 				}
 				if container.Image != "quay.io/test/datamover:latest" {
 					t.Errorf("container image = %q, want %q", container.Image, "quay.io/test/datamover:latest")
@@ -298,7 +298,7 @@ func TestBuildDatamoverPod(t *testing.T) {
 					t.Errorf("another-label = %q, want %q", pod.Labels["another-label"], "another-value")
 				}
 				// Check default labels are still present
-				if pod.Labels[common.LabelDatamoverPod] != "uploader" {
+				if pod.Labels[common.LabelDatamoverPod] != "upload" {
 					t.Errorf("default label missing: %s", common.LabelDatamoverPod)
 				}
 			},

--- a/internal/controller/pv_rebind.go
+++ b/internal/controller/pv_rebind.go
@@ -74,18 +74,19 @@ type PVRebindResult struct {
 // 4. Create new PVC in target namespace with volumeName and selector
 // 5. Reset PV binding: set claimRef to new PVC, add labels (using Patch)
 // 6. Wait for PV to bind to new PVC
-func (r *KubeVirtDataUploadReconciler) rebindPVToNamespace(
+func rebindPVToNamespace(
 	ctx context.Context,
+	k8sClient client.Client,
 	logger logr.Logger,
 	sourcePVCName string,
 	sourceNamespace string,
 	targetNamespace string,
-	dataUploadName string,
-	dataUploadUID string,
+	resourceName string,
+	resourceUID string,
 ) (*PVRebindResult, error) {
 	// Step 1: Get the source PVC and its bound PV
 	sourcePVC := &corev1.PersistentVolumeClaim{}
-	if err := r.Get(ctx, types.NamespacedName{Name: sourcePVCName, Namespace: sourceNamespace}, sourcePVC); err != nil {
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: sourcePVCName, Namespace: sourceNamespace}, sourcePVC); err != nil {
 		return nil, fmt.Errorf("failed to get source PVC %s/%s: %w", sourceNamespace, sourcePVCName, err)
 	}
 
@@ -99,7 +100,7 @@ func (r *KubeVirtDataUploadReconciler) rebindPVToNamespace(
 	}
 
 	pv := &corev1.PersistentVolume{}
-	if err := r.Get(ctx, types.NamespacedName{Name: pvName}, pv); err != nil {
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: pvName}, pv); err != nil {
 		return nil, fmt.Errorf("failed to get PV %s: %w", pvName, err)
 	}
 
@@ -108,20 +109,20 @@ func (r *KubeVirtDataUploadReconciler) rebindPVToNamespace(
 	// Step 2: Set PV reclaim policy to Retain using Patch
 	originalReclaimPolicy := pv.Spec.PersistentVolumeReclaimPolicy
 	if pv.Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimRetain {
-		if err := r.patchPVReclaimPolicy(ctx, pv, corev1.PersistentVolumeReclaimRetain); err != nil {
+		if err := patchPVReclaimPolicy(ctx, k8sClient, pv, corev1.PersistentVolumeReclaimRetain); err != nil {
 			return nil, fmt.Errorf("failed to set PV %s reclaim policy to Retain: %w", pvName, err)
 		}
 		logger.Info("Set PV reclaim policy to Retain", "pv", pvName, "originalPolicy", originalReclaimPolicy)
 	}
 
 	// Step 3: Delete the source PVC
-	if err := r.Delete(ctx, sourcePVC); err != nil && !errors.IsNotFound(err) {
+	if err := k8sClient.Delete(ctx, sourcePVC); err != nil && !errors.IsNotFound(err) {
 		return nil, fmt.Errorf("failed to delete source PVC %s/%s: %w", sourceNamespace, sourcePVCName, err)
 	}
 	logger.Info("Deleted source PVC", "pvc", sourcePVCName, "namespace", sourceNamespace)
 
 	// Wait for PVC to be fully deleted
-	if err := r.waitForPVCDeletion(ctx, sourcePVCName, sourceNamespace); err != nil {
+	if err := waitForPVCDeletion(ctx, k8sClient, sourcePVCName, sourceNamespace); err != nil {
 		return nil, fmt.Errorf("failed waiting for source PVC deletion: %w", err)
 	}
 
@@ -129,17 +130,17 @@ func (r *KubeVirtDataUploadReconciler) rebindPVToNamespace(
 	// Use LabelDataUploadUID for labels/selector (always ≤ 63 chars) instead of
 	// LabelDataUploadName which can exceed the 63-char Kubernetes label value limit.
 	labelKey := common.LabelDataUploadUID
-	labelValue := dataUploadUID
-	newPVCName := common.SafeResourceName(common.ReboundPVCNamePrefix, dataUploadName)
+	labelValue := resourceUID
+	newPVCName := common.SafeResourceName(common.ReboundPVCNamePrefix, resourceName)
 	newPVC := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      newPVCName,
 			Namespace: targetNamespace,
 			Labels: map[string]string{
-				common.LabelDataUploadUID: dataUploadUID,
+				common.LabelDataUploadUID: resourceUID,
 			},
 			Annotations: map[string]string{
-				common.AnnotationDataUploadName: dataUploadName,
+				common.AnnotationDataUploadName: resourceName,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -158,7 +159,7 @@ func (r *KubeVirtDataUploadReconciler) rebindPVToNamespace(
 		},
 	}
 
-	if err := r.Create(ctx, newPVC); err != nil {
+	if err := k8sClient.Create(ctx, newPVC); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return nil, fmt.Errorf("failed to create new PVC %s/%s: %w", targetNamespace, newPVCName, err)
 		}
@@ -169,18 +170,18 @@ func (r *KubeVirtDataUploadReconciler) rebindPVToNamespace(
 
 	// Step 5: Reset PV binding using Patch (like Velero's ResetPVBinding)
 	// Re-fetch PV to get latest version
-	if err := r.Get(ctx, types.NamespacedName{Name: pvName}, pv); err != nil {
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: pvName}, pv); err != nil {
 		return nil, fmt.Errorf("failed to re-fetch PV %s: %w", pvName, err)
 	}
 
 	labels := map[string]string{labelKey: labelValue}
-	if err := r.patchPVBinding(ctx, pv, newPVC, labels); err != nil {
+	if err := patchPVBinding(ctx, k8sClient, pv, newPVC, labels); err != nil {
 		return nil, fmt.Errorf("failed to reset PV %s binding: %w", pvName, err)
 	}
 	logger.Info("Reset PV binding to new PVC", "pv", pvName, "newPVC", newPVCName, "namespace", targetNamespace)
 
 	// Step 6: Wait for PV to bind to new PVC
-	if err := r.waitForPVCBound(ctx, newPVCName, targetNamespace); err != nil {
+	if err := waitForPVCBound(ctx, k8sClient, newPVCName, targetNamespace); err != nil {
 		return nil, fmt.Errorf("failed waiting for new PVC to bind: %w", err)
 	}
 	logger.Info("New PVC is bound to PV", "pvc", newPVCName, "pv", pvName)
@@ -193,20 +194,19 @@ func (r *KubeVirtDataUploadReconciler) rebindPVToNamespace(
 	}, nil
 }
 
-// patchPVReclaimPolicy patches a PV to set its reclaim policy (like Velero's SetPVReclaimPolicy)
+// patchPVReclaimPolicy patches a PV to set its reclaim policy (like Velero's SetPVReclaimPolicy).
 // Includes retry logic for transient errors.
-func (r *KubeVirtDataUploadReconciler) patchPVReclaimPolicy(ctx context.Context, pv *corev1.PersistentVolume, policy corev1.PersistentVolumeReclaimPolicy) error {
+func patchPVReclaimPolicy(ctx context.Context, k8sClient client.Client, pv *corev1.PersistentVolume, policy corev1.PersistentVolumeReclaimPolicy) error {
 	var lastErr error
 	for attempt := 1; attempt <= PatchRetryAttempts; attempt++ {
-		err := r.doPatchPVReclaimPolicy(ctx, pv, policy)
+		err := doPatchPVReclaimPolicy(ctx, k8sClient, pv, policy)
 		if err == nil {
 			return nil
 		}
 		lastErr = err
 		if attempt < PatchRetryAttempts {
 			time.Sleep(PatchRetryInterval)
-			// Re-fetch PV to get latest version for next attempt
-			if fetchErr := r.Get(ctx, types.NamespacedName{Name: pv.Name}, pv); fetchErr != nil {
+			if fetchErr := k8sClient.Get(ctx, types.NamespacedName{Name: pv.Name}, pv); fetchErr != nil {
 				return fmt.Errorf("failed to re-fetch PV after patch error: %w", fetchErr)
 			}
 		}
@@ -214,8 +214,7 @@ func (r *KubeVirtDataUploadReconciler) patchPVReclaimPolicy(ctx context.Context,
 	return fmt.Errorf("failed after %d attempts: %w", PatchRetryAttempts, lastErr)
 }
 
-// doPatchPVReclaimPolicy performs a single patch attempt
-func (r *KubeVirtDataUploadReconciler) doPatchPVReclaimPolicy(ctx context.Context, pv *corev1.PersistentVolume, policy corev1.PersistentVolumeReclaimPolicy) error {
+func doPatchPVReclaimPolicy(ctx context.Context, k8sClient client.Client, pv *corev1.PersistentVolume, policy corev1.PersistentVolumeReclaimPolicy) error {
 	origBytes, err := json.Marshal(pv)
 	if err != nil {
 		return fmt.Errorf("error marshaling original PV: %w", err)
@@ -234,23 +233,22 @@ func (r *KubeVirtDataUploadReconciler) doPatchPVReclaimPolicy(ctx context.Contex
 		return fmt.Errorf("error creating merge patch for PV: %w", err)
 	}
 
-	return r.Patch(ctx, pv, client.RawPatch(types.MergePatchType, patchBytes))
+	return k8sClient.Patch(ctx, pv, client.RawPatch(types.MergePatchType, patchBytes))
 }
 
-// patchPVBinding patches a PV to reset its binding info (like Velero's ResetPVBinding)
+// patchPVBinding patches a PV to reset its binding info (like Velero's ResetPVBinding).
 // Includes retry logic for transient errors.
-func (r *KubeVirtDataUploadReconciler) patchPVBinding(ctx context.Context, pv *corev1.PersistentVolume, pvc *corev1.PersistentVolumeClaim, labels map[string]string) error {
+func patchPVBinding(ctx context.Context, k8sClient client.Client, pv *corev1.PersistentVolume, pvc *corev1.PersistentVolumeClaim, labels map[string]string) error {
 	var lastErr error
 	for attempt := 1; attempt <= PatchRetryAttempts; attempt++ {
-		err := r.doPatchPVBinding(ctx, pv, pvc, labels)
+		err := doPatchPVBinding(ctx, k8sClient, pv, pvc, labels)
 		if err == nil {
 			return nil
 		}
 		lastErr = err
 		if attempt < PatchRetryAttempts {
 			time.Sleep(PatchRetryInterval)
-			// Re-fetch PV to get latest version for next attempt
-			if fetchErr := r.Get(ctx, types.NamespacedName{Name: pv.Name}, pv); fetchErr != nil {
+			if fetchErr := k8sClient.Get(ctx, types.NamespacedName{Name: pv.Name}, pv); fetchErr != nil {
 				return fmt.Errorf("failed to re-fetch PV after patch error: %w", fetchErr)
 			}
 		}
@@ -258,25 +256,21 @@ func (r *KubeVirtDataUploadReconciler) patchPVBinding(ctx context.Context, pv *c
 	return fmt.Errorf("failed after %d attempts: %w", PatchRetryAttempts, lastErr)
 }
 
-// doPatchPVBinding performs a single patch attempt
-func (r *KubeVirtDataUploadReconciler) doPatchPVBinding(ctx context.Context, pv *corev1.PersistentVolume, pvc *corev1.PersistentVolumeClaim, labels map[string]string) error {
+func doPatchPVBinding(ctx context.Context, k8sClient client.Client, pv *corev1.PersistentVolume, pvc *corev1.PersistentVolumeClaim, labels map[string]string) error {
 	origBytes, err := json.Marshal(pv)
 	if err != nil {
 		return fmt.Errorf("error marshaling original PV: %w", err)
 	}
 
 	updated := pv.DeepCopy()
-	// Set claimRef to new PVC (without UID, like Velero)
 	updated.Spec.ClaimRef = &corev1.ObjectReference{
 		Kind:      "PersistentVolumeClaim",
 		Namespace: pvc.Namespace,
 		Name:      pvc.Name,
 	}
-	// Remove bound-by-controller annotation
 	if updated.Annotations != nil {
 		delete(updated.Annotations, KubeAnnBoundByController)
 	}
-	// Add labels for selector matching
 	if labels != nil {
 		if updated.Labels == nil {
 			updated.Labels = make(map[string]string)
@@ -294,14 +288,14 @@ func (r *KubeVirtDataUploadReconciler) doPatchPVBinding(ctx context.Context, pv 
 		return fmt.Errorf("error creating merge patch for PV: %w", err)
 	}
 
-	return r.Patch(ctx, pv, client.RawPatch(types.MergePatchType, patchBytes))
+	return k8sClient.Patch(ctx, pv, client.RawPatch(types.MergePatchType, patchBytes))
 }
 
-// waitForPVCDeletion waits for a PVC to be fully deleted
-func (r *KubeVirtDataUploadReconciler) waitForPVCDeletion(ctx context.Context, pvcName, namespace string) error {
+// waitForPVCDeletion waits for a PVC to be fully deleted.
+func waitForPVCDeletion(ctx context.Context, k8sClient client.Client, pvcName, namespace string) error {
 	return wait.PollUntilContextTimeout(ctx, PVRebindPollInterval, PVRebindTimeout, true, func(ctx context.Context) (bool, error) {
 		pvc := &corev1.PersistentVolumeClaim{}
-		err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: namespace}, pvc)
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: namespace}, pvc)
 		if errors.IsNotFound(err) {
 			return true, nil
 		}
@@ -312,14 +306,12 @@ func (r *KubeVirtDataUploadReconciler) waitForPVCDeletion(ctx context.Context, p
 	})
 }
 
-// waitForPVCBound waits for a PVC to be bound
-func (r *KubeVirtDataUploadReconciler) waitForPVCBound(ctx context.Context, pvcName, namespace string) error {
+// waitForPVCBound waits for a PVC to be bound.
+func waitForPVCBound(ctx context.Context, k8sClient client.Client, pvcName, namespace string) error {
 	return wait.PollUntilContextTimeout(ctx, PVRebindPollInterval, PVRebindTimeout, true, func(ctx context.Context) (bool, error) {
 		pvc := &corev1.PersistentVolumeClaim{}
-		if err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: namespace}, pvc); err != nil {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: namespace}, pvc); err != nil {
 			if errors.IsNotFound(err) {
-				// With a cached client, the PVC can be briefly invisible after creation.
-				// Treat NotFound as a transient condition and keep polling.
 				return false, nil
 			}
 			return false, err
@@ -331,46 +323,40 @@ func (r *KubeVirtDataUploadReconciler) waitForPVCBound(ctx context.Context, pvcN
 // cleanupReboundPVCAndPV deletes the rebound PVC and PV after upload completes.
 // The dataUploadUID is used to find the PV by label if the PVC is already gone,
 // preventing storage leakage.
-func (r *KubeVirtDataUploadReconciler) cleanupReboundPVCAndPV(
+func cleanupReboundPVCAndPV(
 	ctx context.Context,
+	k8sClient client.Client,
 	logger logr.Logger,
 	pvcName string,
 	pvcNamespace string,
-	dataUploadUID string,
+	resourceUID string,
 ) error {
 	var pvName string
 
-	// Get the PVC to find the PV name
 	pvc := &corev1.PersistentVolumeClaim{}
-	err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: pvcNamespace}, pvc)
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: pvcNamespace}, pvc)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(1).Info("Rebound PVC already deleted, will find PV by label", "pvc", pvcName)
-			// PVC is gone, but we still need to clean up the PV to prevent storage leakage.
-			// Find PV by the label we set during rebind.
 		} else {
 			return fmt.Errorf("failed to get rebound PVC %s/%s: %w", pvcNamespace, pvcName, err)
 		}
 	} else {
 		pvName = pvc.Spec.VolumeName
 
-		// Delete the PVC first
-		if err := r.Delete(ctx, pvc); err != nil && !errors.IsNotFound(err) {
+		if err := k8sClient.Delete(ctx, pvc); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete rebound PVC %s/%s: %w", pvcNamespace, pvcName, err)
 		}
 		logger.Info("Deleted rebound PVC", "pvc", pvcName, "namespace", pvcNamespace)
 
-		// Wait for PVC deletion
-		if err := r.waitForPVCDeletion(ctx, pvcName, pvcNamespace); err != nil {
+		if err := waitForPVCDeletion(ctx, k8sClient, pvcName, pvcNamespace); err != nil {
 			logger.Error(err, "Timeout waiting for PVC deletion", "pvc", pvcName)
-			// Continue to try deleting PV anyway
 		}
 	}
 
-	// Find PV by name if we got it from PVC, otherwise find by label
 	pv := &corev1.PersistentVolume{}
 	if pvName != "" {
-		if err := r.Get(ctx, types.NamespacedName{Name: pvName}, pv); err != nil {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: pvName}, pv); err != nil {
 			if errors.IsNotFound(err) {
 				logger.V(1).Info("PV already deleted", "pv", pvName)
 				return nil
@@ -378,13 +364,12 @@ func (r *KubeVirtDataUploadReconciler) cleanupReboundPVCAndPV(
 			return fmt.Errorf("failed to get PV %s: %w", pvName, err)
 		}
 	} else {
-		// Find PV by label (PVC was already deleted)
 		pvList := &corev1.PersistentVolumeList{}
-		if err := r.List(ctx, pvList, client.MatchingLabels{common.LabelDataUploadUID: dataUploadUID}); err != nil {
+		if err := k8sClient.List(ctx, pvList, client.MatchingLabels{common.LabelDataUploadUID: resourceUID}); err != nil {
 			return fmt.Errorf("failed to list PVs by label: %w", err)
 		}
 		if len(pvList.Items) == 0 {
-			logger.V(1).Info("No PV found with label, already cleaned up", "label", common.LabelDataUploadUID, "value", dataUploadUID)
+			logger.V(1).Info("No PV found with label, already cleaned up", "label", common.LabelDataUploadUID, "value", resourceUID)
 			return nil
 		}
 		if len(pvList.Items) > 1 {
@@ -395,15 +380,12 @@ func (r *KubeVirtDataUploadReconciler) cleanupReboundPVCAndPV(
 		logger.Info("Found PV by label", "pv", pvName, "label", common.LabelDataUploadUID)
 	}
 
-	// Set reclaim policy to Delete to ensure underlying storage is cleaned up
-	// This includes retry logic. If it fails, we must NOT delete the PV
-	// because that would orphan the underlying storage (storage leakage).
-	if err := r.patchPVReclaimPolicy(ctx, pv, corev1.PersistentVolumeReclaimDelete); err != nil {
+	if err := patchPVReclaimPolicy(ctx, k8sClient, pv, corev1.PersistentVolumeReclaimDelete); err != nil {
 		logger.Error(err, "Failed to set PV reclaim policy to Delete after retries", "pv", pvName)
 		return fmt.Errorf("cannot delete PV %s: failed to set reclaim policy to Delete (would cause storage leakage): %w", pvName, err)
 	}
 
-	if err := r.Delete(ctx, pv); err != nil && !errors.IsNotFound(err) {
+	if err := k8sClient.Delete(ctx, pv); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete PV %s: %w", pvName, err)
 	}
 	logger.Info("Deleted PV", "pv", pvName)

--- a/internal/controller/pv_rebind.go
+++ b/internal/controller/pv_rebind.go
@@ -83,6 +83,8 @@ func rebindPVToNamespace(
 	targetNamespace string,
 	resourceName string,
 	resourceUID string,
+	uidLabelKey string,
+	nameAnnotationKey string,
 ) (*PVRebindResult, error) {
 	// Step 1: Get the source PVC and its bound PV
 	sourcePVC := &corev1.PersistentVolumeClaim{}
@@ -127,9 +129,7 @@ func rebindPVToNamespace(
 	}
 
 	// Step 4: Create new PVC in target namespace with volumeName and selector
-	// Use LabelDataUploadUID for labels/selector (always ≤ 63 chars) instead of
-	// LabelDataUploadName which can exceed the 63-char Kubernetes label value limit.
-	labelKey := common.LabelDataUploadUID
+	labelKey := uidLabelKey
 	labelValue := resourceUID
 	newPVCName := common.SafeResourceName(common.ReboundPVCNamePrefix, resourceName)
 	newPVC := &corev1.PersistentVolumeClaim{
@@ -137,10 +137,10 @@ func rebindPVToNamespace(
 			Name:      newPVCName,
 			Namespace: targetNamespace,
 			Labels: map[string]string{
-				common.LabelDataUploadUID: resourceUID,
+				uidLabelKey: resourceUID,
 			},
 			Annotations: map[string]string{
-				common.AnnotationDataUploadName: resourceName,
+				nameAnnotationKey: resourceName,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -320,8 +320,8 @@ func waitForPVCBound(ctx context.Context, k8sClient client.Client, pvcName, name
 	})
 }
 
-// cleanupReboundPVCAndPV deletes the rebound PVC and PV after upload completes.
-// The dataUploadUID is used to find the PV by label if the PVC is already gone,
+// cleanupReboundPVCAndPV deletes the rebound PVC and PV after a datamover operation completes.
+// The resourceUID is used to find the PV by label if the PVC is already gone,
 // preventing storage leakage.
 func cleanupReboundPVCAndPV(
 	ctx context.Context,
@@ -330,6 +330,7 @@ func cleanupReboundPVCAndPV(
 	pvcName string,
 	pvcNamespace string,
 	resourceUID string,
+	uidLabelKey string,
 ) error {
 	var pvName string
 
@@ -365,11 +366,11 @@ func cleanupReboundPVCAndPV(
 		}
 	} else {
 		pvList := &corev1.PersistentVolumeList{}
-		if err := k8sClient.List(ctx, pvList, client.MatchingLabels{common.LabelDataUploadUID: resourceUID}); err != nil {
+		if err := k8sClient.List(ctx, pvList, client.MatchingLabels{uidLabelKey: resourceUID}); err != nil {
 			return fmt.Errorf("failed to list PVs by label: %w", err)
 		}
 		if len(pvList.Items) == 0 {
-			logger.V(1).Info("No PV found with label, already cleaned up", "label", common.LabelDataUploadUID, "value", resourceUID)
+			logger.V(1).Info("No PV found with label, already cleaned up", "label", uidLabelKey, "value", resourceUID)
 			return nil
 		}
 		if len(pvList.Items) > 1 {
@@ -377,7 +378,7 @@ func cleanupReboundPVCAndPV(
 		}
 		pv = &pvList.Items[0]
 		pvName = pv.Name
-		logger.Info("Found PV by label", "pv", pvName, "label", common.LabelDataUploadUID)
+		logger.Info("Found PV by label", "pv", pvName, "label", uidLabelKey)
 	}
 
 	if err := patchPVReclaimPolicy(ctx, k8sClient, pv, corev1.PersistentVolumeReclaimDelete); err != nil {

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -121,13 +121,15 @@ const (
 	VMBackupNamePrefix = "vmb-"
 )
 
-// Pod type values used with LabelDatamoverPod
+// Pod type values used with LabelDatamoverPod.
+// These match OperationMode values in the pod builder so label selectors
+// and pod builder stay consistent.
 const (
-	// PodTypeUploader identifies a datamover pod running the upload path.
-	PodTypeUploader = "uploader"
+	// PodTypeUpload identifies a datamover pod running the upload (backup) path.
+	PodTypeUpload = "upload"
 
-	// PodTypeDownloader identifies a datamover pod running the download path.
-	PodTypeDownloader = "downloader"
+	// PodTypeDownload identifies a datamover pod running the download (restore) path.
+	PodTypeDownload = "download"
 )
 
 // DataMover identifier

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -18,7 +18,7 @@ limitations under the License.
 // the kubevirt-datamover-controller and kubevirt-datamover-plugin.
 package common
 
-// Annotation keys for DataUpload resources
+// Annotation keys for DataUpload and DataDownload resources
 const (
 	// AnnotationVMName is the annotation key for the source VirtualMachine name.
 	// This annotation is set on the DataUpload/DataDownload by the plugin to identify

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -21,12 +21,12 @@ package common
 // Annotation keys for DataUpload resources
 const (
 	// AnnotationVMName is the annotation key for the source VirtualMachine name.
-	// This annotation is set on the DataUpload by the plugin to identify
-	// which VM should be backed up.
+	// This annotation is set on the DataUpload/DataDownload by the plugin to identify
+	// which VM should be backed up or restored.
 	AnnotationVMName = "kubevirt-datamover.io/vm-name"
 
 	// AnnotationVMNamespace is the annotation key for the source VirtualMachine namespace.
-	// If not set, the controller will use the DataUpload's source namespace.
+	// If not set, the controller will use the DataUpload/DataDownload's source namespace.
 	AnnotationVMNamespace = "kubevirt-datamover.io/vm-namespace"
 
 	// AnnotationOperationID is the annotation for tracking async backup/restore operations.
@@ -52,6 +52,10 @@ const (
 	// AnnotationDataUploadName is the annotation key for the DataUpload name.
 	// Used on VMB, VMBT, and PVC resources to track ownership.
 	AnnotationDataUploadName = "velero.io/dataupload-name"
+
+	// AnnotationDataDownloadName is the annotation key for the DataDownload name.
+	// Used on PVC and pod resources to track ownership during restore.
+	AnnotationDataDownloadName = "velero.io/datadownload-name"
 )
 
 // Annotation keys for VirtualMachine resources
@@ -72,6 +76,11 @@ const (
 	// Used for precise ownership tracking and label-based lookups.
 	LabelDataUploadUID = "velero.io/dataupload-uid"
 
+	// LabelDataDownloadUID is the label key for the DataDownload UID.
+	// UIDs are always 36 characters, safe for label values.
+	// Used for precise ownership tracking and label-based lookups during restore.
+	LabelDataDownloadUID = "velero.io/datadownload-uid"
+
 	// LabelVMNameHash is the label key for a hashed VM name on VMBTs.
 	// VM names can exceed the 63-char label limit, so we store a 16-char
 	// hex hash for label-based lookups and the full name in an annotation.
@@ -82,21 +91,43 @@ const (
 
 	// LabelVeleroBackupName is the label key for the Velero backup name.
 	LabelVeleroBackupName = "velero.io/backup-name"
+
+	// LabelVeleroRestoreName is the label key for the Velero restore name.
+	LabelVeleroRestoreName = "velero.io/restore-name"
 )
 
 // Naming conventions for resources
 const (
-	// DatamoverPodNamePrefix is the prefix for datamover pod names.
+	// DatamoverPodNamePrefix is the prefix for datamover upload pod names.
 	DatamoverPodNamePrefix = "kubevirt-dm-"
 
-	// TempPVCNamePrefix is the prefix for temporary PVC names.
+	// DownloaderPodNamePrefix is the prefix for datamover download pod names.
+	DownloaderPodNamePrefix = "kubevirt-dm-dl-"
+
+	// TempPVCNamePrefix is the prefix for temporary backup PVC names.
 	TempPVCNamePrefix = "kubevirt-backup-"
+
+	// ScratchPVCNamePrefix is the prefix for temporary scratch PVCs used during restore
+	// to hold downloaded qcow2 files before chain reconstruction.
+	ScratchPVCNamePrefix = "kubevirt-restore-scratch-"
+
+	// TargetPVCNamePrefix is the prefix for restored disk PVCs.
+	TargetPVCNamePrefix = "kubevirt-restore-"
 
 	// ReboundPVCNamePrefix is the prefix for PVCs created in OADP namespace after PV rebinding.
 	ReboundPVCNamePrefix = "kubevirt-dm-pvc-"
 
 	// VMBackupNamePrefix is the prefix for VirtualMachineBackup names.
 	VMBackupNamePrefix = "vmb-"
+)
+
+// Pod type values used with LabelDatamoverPod
+const (
+	// PodTypeUploader identifies a datamover pod running the upload path.
+	PodTypeUploader = "uploader"
+
+	// PodTypeDownloader identifies a datamover pod running the download path.
+	PodTypeDownloader = "downloader"
 )
 
 // DataMover identifier
@@ -148,6 +179,35 @@ const (
 //
 //   InProgress -> Completed:
 //     - Plugin monitors datamover pod progress
+//     - Transitions to Completed when data transfer finishes
+//
+//   Any -> Failed:
+//     - Any phase can transition to Failed on errors
+//
+//   InProgress -> Canceling -> Canceled:
+//     - Cancellation support (handles user-initiated cancel requests)
+//
+// DataDownload Phase Transitions (for documentation):
+//
+// The kubevirt-datamover-controller handles the following phase transitions
+// for DataDownload CRs:
+//
+//   New -> Accepted:
+//     - Controller validates VM annotations and BSL accessibility
+//     - Transitions to Accepted if valid, Failed if missing
+//
+//   Accepted -> Prepared:
+//     - Controller reads backup manifest from BSL to get checkpoint chain
+//     - Creates scratch PVC for downloaded qcow2 files
+//     - Transitions to Prepared when ready
+//
+//   Prepared -> InProgress:
+//     - Controller launches downloader pod to download and reconstruct disk
+//     - Pod downloads checkpoint chain, runs qemu-img to flatten to raw
+//
+//   InProgress -> Completed:
+//     - Controller monitors downloader pod progress
+//     - Provisions target PVC with restored disk data
 //     - Transitions to Completed when data transfer finishes
 //
 //   Any -> Failed:


### PR DESCRIPTION
## Summary
- Rebase Dockerfile from distroless to CentOS Stream 9 minimal with `qemu-img` for restore path (issue #45)
- Add DataDownload identity contract constants (annotations, labels, naming prefixes, pod type values)
- Extract shared controller helpers to `internal/controller/helpers.go` and convert `pv_rebind.go` to standalone functions with generic label/annotation key params
- Add `OperationMode` to pod builder supporting upload/download modes with per-mode identity labels

## Context

This is the first PR in the phased implementation plan for #73 (DataDownload controller). It lands prerequisites (Phase 0) and shared plumbing (Phase 1) so the DataDownload controller (Phase 3) can reuse helpers without duplicating ~500 lines of DataUpload logic.

**Breaking change**: Pod label `kubevirt-datamover.io/pod-type` value changed from `"uploader"` to `"upload"` to align with `OperationMode` constants. No external consumers of this label exist yet.

**Note**: `OperationModeDownload` sets command to `/manager download`, but the `download` subcommand dispatch in `cmd/main.go` is Phase 3 work. Download mode pods are not created by this PR.

## Test plan
- [x] `make test` — all unit tests pass (including new download mode test)
- [x] `make lint` — 0 issues
- [x] `go build ./...` — compiles clean
- [x] CI — all checks green (Lint, Tests, E2E)

Ref: #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable datamover operation modes (upload/download) and improved restore/downloader labeling and tracking.
* **Bug Fixes**
  * Improved BackupStorageLocation resolution and checkpoint-chain validation behavior.
  * More reliable datamover pod discovery, failure reporting, and cleanup using UID-based handling.
* **Refactor**
  * Streamlined persistent-volume rebinding and datamover lifecycle management with clearer identifier semantics.
* **Chores**
  * Updated the runtime container image and installed required runtime tooling.
* **Tests**
  * Updated unit tests to cover the refactored controller logic and download-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->