### PR TITLE
Stream datamover pod logs to controller on pod termination

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	kubevirtbackupv1alpha1 "kubevirt.io/api/backup/v1alpha1"
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
@@ -226,6 +227,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	kubeClient, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		setupLog.Error(err, "unable to create kubernetes clientset")
+		os.Exit(1)
+	}
+
 	// Setup KubeVirt DataUpload controller
 	if err = (&controller.KubeVirtDataUploadReconciler{
 		Client:                   mgr.GetClient(),
@@ -236,6 +243,7 @@ func main() {
 		DatamoverImagePullPolicy: corev1.PullPolicy(datamoverImagePullPolicy),
 		MaxIncrementalBackups:    maxIncrementalBackups,
 		OADPNamespace:            oadpNamespace,
+		PodLogCollector:          controller.NewPodLogCollector(kubeClient, 100),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeVirtDataUpload")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,6 +40,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/go-logr/logr"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -26,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/migtools/kubevirt-datamover-controller/pkg/common"
@@ -137,4 +139,24 @@ func getVeleroBackupName(labels map[string]string) string {
 		return ""
 	}
 	return labels[common.LabelVeleroBackupName]
+}
+
+// NewPodLogCollector returns a PodLogCollector function that reads the last
+// tailLines of log output from a pod using the Kubernetes API.
+func NewPodLogCollector(clientset kubernetes.Interface, tailLines int64) func(ctx context.Context, podName, podNamespace string) (string, error) {
+	return func(ctx context.Context, podName, podNamespace string) (string, error) {
+		opts := &corev1.PodLogOptions{
+			TailLines: &tailLines,
+		}
+		stream, err := clientset.CoreV1().Pods(podNamespace).GetLogs(podName, opts).Stream(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to stream pod logs: %w", err)
+		}
+		defer stream.Close()
+		data, err := io.ReadAll(stream)
+		if err != nil {
+			return "", fmt.Errorf("failed to read pod logs: %w", err)
+		}
+		return string(data), nil
+	}
 }

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -152,7 +152,7 @@ func NewPodLogCollector(clientset kubernetes.Interface, tailLines int64) func(ct
 		if err != nil {
 			return "", fmt.Errorf("failed to stream pod logs: %w", err)
 		}
-		defer stream.Close()
+		defer func() { _ = stream.Close() }()
 		data, err := io.ReadAll(stream)
 		if err != nil {
 			return "", fmt.Errorf("failed to read pod logs: %w", err)

--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -101,6 +101,10 @@ type KubeVirtDataUploadReconciler struct {
 	// ObjectStoreFactory creates an ObjectStore from an UploaderConfig.
 	// Defaults to uploader.InitObjectStore if nil. Override in tests to inject mocks.
 	ObjectStoreFactory func(cfg *uploader.UploaderConfig) (velero.ObjectStore, error)
+
+	// PodLogCollector reads logs from a completed datamover pod.
+	// If nil, pod log collection is skipped. Override in tests to inject mocks.
+	PodLogCollector func(ctx context.Context, podName, podNamespace string) (string, error)
 }
 
 // +kubebuilder:rbac:groups=velero.io,resources=datauploads,verbs=get;list;watch;update;patch
@@ -113,6 +117,7 @@ type KubeVirtDataUploadReconciler struct {
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups="",resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines,verbs=get;list;watch
 
@@ -871,6 +876,8 @@ func (r *KubeVirtDataUploadReconciler) handleInProgress(ctx context.Context, log
 	case corev1.PodSucceeded:
 		logger.Info("Datamover pod completed successfully", "pod", pod.Name)
 
+		r.emitPodLogs(ctx, logger, pod)
+
 		// Cleanup resources
 		r.cleanupDatamoverResources(ctx, logger, du, podNamespace)
 
@@ -882,6 +889,8 @@ func (r *KubeVirtDataUploadReconciler) handleInProgress(ctx context.Context, log
 	case corev1.PodFailed:
 		failureMessage := extractPodFailureMessage(pod)
 		logger.Error(nil, "Datamover pod failed", "pod", pod.Name, "message", failureMessage)
+
+		r.emitPodLogs(ctx, logger, pod)
 
 		// Skip cleanup on failure to preserve resources for debugging.
 		// Resources (pod, rebound PVC/PV) can be manually cleaned up after investigation.
@@ -898,6 +907,31 @@ func (r *KubeVirtDataUploadReconciler) handleInProgress(ctx context.Context, log
 	default:
 		logger.Info("Datamover pod in unknown phase", "pod", pod.Name, "phase", pod.Status.Phase)
 		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
+	}
+}
+
+// emitPodLogs collects logs from a completed datamover pod and emits them
+// through the controller's logger. Failures are logged as warnings and
+// never block the reconcile loop.
+func (r *KubeVirtDataUploadReconciler) emitPodLogs(ctx context.Context, logger logr.Logger, pod *corev1.Pod) {
+	if r.PodLogCollector == nil {
+		return
+	}
+	logs, err := r.PodLogCollector(ctx, pod.Name, pod.Namespace)
+	if err != nil {
+		logger.Info("Warning: failed to collect datamover pod logs", "pod", pod.Name, "error", err)
+		return
+	}
+	if logs == "" {
+		return
+	}
+	lines := strings.Split(strings.TrimRight(logs, "\n"), "\n")
+	for i, line := range lines {
+		logger.Info("Datamover pod log",
+			"source", "datamover-pod",
+			"pod", pod.Name,
+			"line", i+1,
+			"message", line)
 	}
 }
 

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
 	"github.com/migtools/kubevirt-datamover-controller/pkg/common"
 	"github.com/migtools/kubevirt-datamover-controller/pkg/uploader"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -7103,6 +7104,183 @@ func TestGetEffectiveMaxIncrementalBackups(t *testing.T) {
 
 			if result != tt.expectedMax {
 				t.Errorf("getEffectiveMaxIncrementalBackups() = %d, want %d", result, tt.expectedMax)
+			}
+		})
+	}
+}
+
+func TestEmitPodLogs(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datamover-test-pod",
+			Namespace: "openshift-adp",
+		},
+	}
+
+	tests := []struct {
+		name            string
+		collector       func(ctx context.Context, podName, podNamespace string) (string, error)
+		expectLogs      bool
+		expectedLines   int
+		expectCollected bool
+	}{
+		{
+			name:            "nil collector skips log collection",
+			collector:       nil,
+			expectLogs:      false,
+			expectCollected: false,
+		},
+		{
+			name: "collector error logs warning and continues",
+			collector: func(ctx context.Context, podName, podNamespace string) (string, error) {
+				return "", fmt.Errorf("connection refused")
+			},
+			expectLogs:      false,
+			expectCollected: true,
+		},
+		{
+			name: "empty log output emits nothing",
+			collector: func(ctx context.Context, podName, podNamespace string) (string, error) {
+				return "", nil
+			},
+			expectLogs:      false,
+			expectCollected: true,
+		},
+		{
+			name: "multi-line output emits each line",
+			collector: func(ctx context.Context, podName, podNamespace string) (string, error) {
+				return "uploading snapshot\nprogress: 100%\ncompleted\n", nil
+			},
+			expectLogs:      true,
+			expectedLines:   3,
+			expectCollected: true,
+		},
+		{
+			name: "single line without trailing newline",
+			collector: func(ctx context.Context, podName, podNamespace string) (string, error) {
+				return "done", nil
+			},
+			expectLogs:      true,
+			expectedLines:   1,
+			expectCollected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			logger := funcr.New(func(prefix, args string) {
+				logBuf.WriteString(args + "\n")
+			}, funcr.Options{})
+
+			r := &KubeVirtDataUploadReconciler{
+				PodLogCollector: tt.collector,
+			}
+
+			r.emitPodLogs(context.Background(), logger, pod)
+
+			hasLogs := strings.Contains(logBuf.String(), "Datamover pod log")
+			if hasLogs != tt.expectLogs {
+				t.Errorf("expected logs=%v, got logs=%v, output: %s", tt.expectLogs, hasLogs, logBuf.String())
+			}
+
+			if tt.expectLogs {
+				lineCount := strings.Count(logBuf.String(), "Datamover pod log")
+				if lineCount != tt.expectedLines {
+					t.Errorf("expected %d log lines, got %d", tt.expectedLines, lineCount)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleInProgress_PodLogCollectionFailureDoesNotBlock(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = velerov2alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	tests := []struct {
+		name          string
+		podPhase      corev1.PodPhase
+		expectedPhase velerov2alpha1.DataUploadPhase
+	}{
+		{
+			name:          "log failure does not block PodSucceeded",
+			podPhase:      corev1.PodSucceeded,
+			expectedPhase: velerov2alpha1.DataUploadPhaseCompleted,
+		},
+		{
+			name:          "log failure does not block PodFailed",
+			podPhase:      corev1.PodFailed,
+			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			du := &velerov2alpha1.DataUpload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-du",
+					Namespace: "openshift-adp",
+					UID:       types.UID("test-uid-log-fail"),
+					Annotations: map[string]string{
+						common.AnnotationVMName:      "test-vm",
+						common.AnnotationVMNamespace: "test-ns",
+					},
+				},
+				Spec: velerov2alpha1.DataUploadSpec{
+					DataMover: common.DataMoverKubeVirt,
+				},
+				Status: velerov2alpha1.DataUploadStatus{
+					Phase: velerov2alpha1.DataUploadPhaseInProgress,
+				},
+			}
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.DatamoverPodNamePrefix + du.Name,
+					Namespace: "openshift-adp",
+					Labels: map[string]string{
+						common.LabelDataUploadUID: string(du.UID),
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: tt.podPhase,
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(du, pod).
+				Build()
+
+			r := &KubeVirtDataUploadReconciler{
+				Client:        fakeClient,
+				Scheme:        scheme,
+				Log:           logr.Discard(),
+				OADPNamespace: "openshift-adp",
+				PodLogCollector: func(ctx context.Context, podName, podNamespace string) (string, error) {
+					return "", fmt.Errorf("simulated log collection failure")
+				},
+			}
+
+			result, err := r.handleInProgress(context.Background(), logr.Discard(), du)
+			if err != nil {
+				t.Fatalf("handleInProgress should not fail when log collection fails: %v", err)
+			}
+			if result.RequeueAfter != 0 {
+				t.Errorf("expected no requeue, got RequeueAfter=%v", result.RequeueAfter)
+			}
+
+			updatedDU := &velerov2alpha1.DataUpload{}
+			if err := fakeClient.Get(context.Background(), types.NamespacedName{
+				Name:      du.Name,
+				Namespace: du.Namespace,
+			}, updatedDU); err != nil {
+				t.Fatalf("failed to get updated DataUpload: %v", err)
+			}
+			if updatedDU.Status.Phase != tt.expectedPhase {
+				t.Errorf("expected phase=%s, got phase=%s", tt.expectedPhase, updatedDU.Status.Phase)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Collect datamover pod logs via the `pods/log` API when a pod reaches a terminal state (Succeeded or Failed) and emit them through the controller's structured logger
- Add `PodLogCollector` function field to the reconciler (following the `ObjectStoreFactory` pattern) for testability
- Add `pods/log` RBAC permission to the controller's ClusterRole

Fixes: #52

## Details

Datamover pods are ephemeral -- on success they are cleaned up, and on failure only the terse termination reason (e.g. `Error`, `OOMKilled`) is captured. The actual error details (stack traces, S3 errors, credential issues) live in the pod logs and are lost once the pod is garbage collected.

This follows Velero's pattern (`CollectPodLogs()` / `redirectDataMoverLogs()`) of collecting logs post-termination rather than streaming in real-time.

Log collection:
- Runs in `handleInProgress` on `PodSucceeded` (before cleanup) and `PodFailed` (before phase update)
- Captures the last 100 lines via `TailLines` to prevent unbounded memory usage
- Emits each line as a structured log entry with `source=datamover-pod`, pod name, and line number
- Failures warn but never block the reconcile loop

## Test plan

- [x] `TestEmitPodLogs` -- nil collector, error collector, empty output, multi-line output, single line
- [x] `TestHandleInProgress_PodLogCollectionFailureDoesNotBlock` -- verifies reconciliation completes on both Succeeded and Failed paths even when log collection errors
- [x] All existing controller tests pass (nil `PodLogCollector` = silent skip)
- [ ] Manual: deploy controller, run a datamover backup, verify pod logs appear in `kubectl logs <controller-pod>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic collection of datamover pod logs when data uploads complete successfully or fail.
  * Pod log output is recorded line by line for improved troubleshooting.

* **Bug Fixes**
  * Log collection failures no longer prevent cleanup or data upload status transitions.
  * Added required permissions to read pod logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->