### PR TITLE
Fix evaluateVMBackupStatus to read VMBackup failure detail from Reason, not Message

### DIFF
--- a/internal/controller/kubevirt_dataupload_controller.go
+++ b/internal/controller/kubevirt_dataupload_controller.go
@@ -448,14 +448,22 @@ func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 	}
 
 	if doneCond != nil && doneCond.Status == corev1.ConditionTrue {
-		// Done=True can mean "finished with error" — KubeVirt sets Done=True + Reason=Failed
-		// when the backup fails (e.g., "No space left on device"). Check Progressing condition.
-		if progressingCond != nil && progressingCond.Status == corev1.ConditionFalse &&
-			progressingCond.Reason == "Failed" {
+		// Done=True can mean "finished with error" — KubeVirt sets Done=True together with
+		// Progressing=False when the backup fails (e.g., "No space left on device"), but the
+		// Reason is a descriptive string like "Backup has failed: <details>" rather than the
+		// literal "Failed". Detect failure via a case-insensitive "failed" substring match on
+		// either condition, and take the failure detail from whichever condition actually
+		// carries it — never from a condition just because it happens to have non-empty text.
+		var progressingCandidate *kubevirtbackupv1alpha1.Condition
+		if progressingCond != nil && progressingCond.Status == corev1.ConditionFalse {
+			progressingCandidate = progressingCond
+		}
+		if conditionIndicatesFailure(progressingCandidate) || conditionIndicatesFailure(doneCond) {
+			reason, failureMessage := pickFailureDetail(progressingCandidate, doneCond)
 			logger.Error(nil, "VirtualMachineBackup failed (Done=True with failure)",
-				"vmb", vmb.Name, "reason", progressingCond.Reason, "message", progressingCond.Message)
+				"vmb", vmb.Name, "reason", reason, "message", failureMessage)
 			if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
-				fmt.Sprintf("VMBackup failed: %s", progressingCond.Message)); err != nil {
+				fmt.Sprintf("VMBackup failed: %s", failureMessage)); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
@@ -476,9 +484,13 @@ func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 	if doneCond != nil && doneCond.Status == corev1.ConditionFalse {
 		if progressingCond != nil && progressingCond.Status == corev1.ConditionFalse {
 			// Progressing=False + Done=False → actual failure
-			logger.Error(nil, "VirtualMachineBackup failed", "reason", doneCond.Reason, "message", doneCond.Message)
+			reason, failureMessage := pickFailureDetail(doneCond, progressingCond)
+			if failureMessage == "" {
+				failureMessage = fmt.Sprintf("VirtualMachineBackup %s failed (Done=False, Progressing=False) with no failure detail reported", vmb.Name)
+			}
+			logger.Error(nil, "VirtualMachineBackup failed", "reason", reason, "message", failureMessage)
 			if err := r.updatePhase(ctx, du, velerov2alpha1.DataUploadPhaseFailed,
-				fmt.Sprintf("VMBackup failed: %s", doneCond.Message)); err != nil {
+				fmt.Sprintf("VMBackup failed: %s", failureMessage)); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
@@ -517,6 +529,49 @@ func (r *KubeVirtDataUploadReconciler) evaluateVMBackupStatus(
 	// No Done condition yet, or backup still running - requeue
 	logger.Info("VirtualMachineBackup in progress, requeuing")
 	return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
+}
+
+// conditionIndicatesFailure reports whether a VirtualMachineBackup condition's Reason or Message
+// signals a failure. KubeVirt emits descriptive strings such as "Backup has failed: <details>"
+// rather than a fixed "Failed" reason, so we match a case-insensitive "failed" substring.
+func conditionIndicatesFailure(cond *kubevirtbackupv1alpha1.Condition) bool {
+	if cond == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(cond.Reason), "failed") ||
+		strings.Contains(strings.ToLower(cond.Message), "failed")
+}
+
+// vmBackupConditionDetail extracts a human-readable failure detail from a VirtualMachineBackup
+// condition. KubeVirt's CBT backup controller never populates Message on Done/Progressing/
+// Initializing conditions — only Reason carries the descriptive text (e.g. "Backup has failed:
+// No space left on device") — so Reason is used whenever Message is empty.
+func vmBackupConditionDetail(cond *kubevirtbackupv1alpha1.Condition) string {
+	if cond == nil {
+		return ""
+	}
+	if cond.Message != "" {
+		return cond.Message
+	}
+	return cond.Reason
+}
+
+// pickFailureDetail returns the Reason/detail pair from whichever of the two conditions
+// actually indicates a failure (preferring the first argument on a tie), so a neutral
+// status reason on one condition never overrides the real failure detail on the other.
+// Falls back to any non-empty text if neither condition's text matches "failed".
+func pickFailureDetail(preferred, other *kubevirtbackupv1alpha1.Condition) (reason, detail string) {
+	for _, cond := range []*kubevirtbackupv1alpha1.Condition{preferred, other} {
+		if conditionIndicatesFailure(cond) {
+			return cond.Reason, vmBackupConditionDetail(cond)
+		}
+	}
+	for _, cond := range []*kubevirtbackupv1alpha1.Condition{preferred, other} {
+		if cond != nil && vmBackupConditionDetail(cond) != "" {
+			return cond.Reason, vmBackupConditionDetail(cond)
+		}
+	}
+	return "", ""
 }
 
 // resolveBackupMode determines whether to force a full backup or allow incremental.

--- a/internal/controller/kubevirt_dataupload_controller_test.go
+++ b/internal/controller/kubevirt_dataupload_controller_test.go
@@ -642,11 +642,12 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	tests := []struct {
-		name          string
-		vmbConditions []kubevirtbackupv1alpha1.Condition
-		expectedPhase velerov2alpha1.DataUploadPhase
-		expectRequeue bool
-		skipVMBT      bool // when true, do not create the VMBT (simulates deleted VMBT)
+		name                    string
+		vmbConditions           []kubevirtbackupv1alpha1.Condition
+		expectedPhase           velerov2alpha1.DataUploadPhase
+		expectRequeue           bool
+		skipVMBT                bool   // when true, do not create the VMBT (simulates deleted VMBT)
+		expectedMessageContains string // when set, DataUpload's failure message must contain this
 	}{
 		{
 			name: "VMB Done True transitions to Prepared",
@@ -681,8 +682,66 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 					Message: "Backup has failed: No space left on device",
 				},
 			},
-			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
-			expectRequeue: false,
+			expectedPhase:           velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue:           false,
+			expectedMessageContains: "No space left on device",
+		},
+		{
+			name: "VMB Done True with failure detail only on Done (neutral Progressing reason) transitions to Failed",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "NotProgressing",
+				},
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionDone,
+					Status: corev1.ConditionTrue,
+					Reason: "Backup has failed: No space left on device",
+				},
+			},
+			expectedPhase:           velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue:           false,
+			expectedMessageContains: "No space left on device",
+		},
+		{
+			// Real KubeVirt (v1.8.4) never populates Message on these conditions — only Reason
+			// carries the wrapped detail. This case reflects that: Message left empty.
+			name: "VMB Done True with descriptive failure reason transitions to Failed",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "Backup has failed: No space left on device",
+				},
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionDone,
+					Status: corev1.ConditionTrue,
+					Reason: "Backup has failed: No space left on device",
+				},
+			},
+			expectedPhase:           velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue:           false,
+			expectedMessageContains: "No space left on device",
+		},
+		{
+			// Same as above but for the Done=False + Progressing=False failure branch.
+			name: "VMB Done False and Progressing False with descriptive reason (no Message) transitions to Failed",
+			vmbConditions: []kubevirtbackupv1alpha1.Condition{
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionProgressing,
+					Status: corev1.ConditionFalse,
+					Reason: "Backup has failed: VMI was deleted during backup",
+				},
+				{
+					Type:   kubevirtbackupv1alpha1.ConditionDone,
+					Status: corev1.ConditionFalse,
+					Reason: "Backup has failed: VMI was deleted during backup",
+				},
+			},
+			expectedPhase:           velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue:           false,
+			expectedMessageContains: "VMI was deleted during backup",
 		},
 		{
 			name: "VMB Done False and Progressing False transitions to Failed",
@@ -699,8 +758,9 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 					Message: "VM backup failed due to an error",
 				},
 			},
-			expectedPhase: velerov2alpha1.DataUploadPhaseFailed,
-			expectRequeue: false,
+			expectedPhase:           velerov2alpha1.DataUploadPhaseFailed,
+			expectRequeue:           false,
+			expectedMessageContains: "VM backup failed due to an error",
 		},
 		{
 			name: "VMB Done False and Progressing True requeues (backup still running)",
@@ -953,6 +1013,10 @@ func TestHandleAccepted_VMBStatusDetection(t *testing.T) {
 
 			if updatedDU.Status.Phase != tt.expectedPhase {
 				t.Errorf("expected phase=%s, got phase=%s", tt.expectedPhase, updatedDU.Status.Phase)
+			}
+
+			if tt.expectedMessageContains != "" && !strings.Contains(updatedDU.Status.Message, tt.expectedMessageContains) {
+				t.Errorf("expected message to contain %q, got message=%q", tt.expectedMessageContains, updatedDU.Status.Message)
 			}
 		})
 	}


### PR DESCRIPTION
Supersedes #109.

## Problem

#109 fixed `evaluateVMBackupStatus` to detect `VirtualMachineBackup` failures that show up as `Done=True` (rather than an explicit `Failed` condition), and pulled the human-readable failure detail from `progressingCond.Message` / `doneCond.Message` with a fallback chain between the two.

However, KubeVirt's real CBT backup controller (`newCondition()` in `pkg/storage/cbt/backup.go`, confirmed against both v1.8.4 and the current source) never populates `Condition.Message` on the `Done`/`Progressing`/`Initializing` conditions — only `Reason` carries the descriptive text, e.g.:

```go
Reason: "Backup has failed: No space left on device"
Message: "" // always empty in production
```

Because #109's fallback chain only reads `.Message`, the resulting `DataUpload.Status.Message` is always empty in real clusters — the phase is correctly set to `Failed`, but the actual failure detail (why it failed) is lost.

This was masked in #109's own tests because the test fixtures set `Message` identically to `Reason`, which doesn't reflect what the real KubeVirt controller produces.

## Fix

- Add `vmBackupConditionDetail()`: prefers `Message` when present, falls back to `Reason` when `Message` is empty. Used in both failure-detection branches of `evaluateVMBackupStatus` (the `Done=True` branch and the `Done=False && Progressing=False` branch).
- Fix a logging nit: the logged `"reason"` field now always corresponds to whichever condition (`progressingCond` or `doneCond`) actually supplied the failure detail, instead of being hardcoded.
- Update `TestHandleAccepted_VMBStatusDetection`:
  - Add an `expectedMessageContains` field + assertion so tests actually verify message *content*, not just phase/requeue (this is what let the empty-message bug go unnoticed).
  - Replace the unrealistic `Message == Reason` test fixture with one matching real KubeVirt v1.8.4 output (`Message` empty, detail only in `Reason`).
  - Add a new case covering the `Done=False && Progressing=False` failure branch with the same realistic (empty-`Message`) shape.

## Testing

- `go build ./...` — clean
- `go test ./... ` — all packages pass
- `go test ./internal/controller/... -run TestHandleAccepted_VMBStatusDetection -v` — all 12 subtests pass, including the two new/updated cases asserting on actual message content
- `go vet ./...` — clean
- `gofmt -l` — clean
- `golangci-lint run ./internal/controller/...` — no new issues (10 pre-existing `goconst` hits unrelated to this change)

> [!Note]
> Responses generated with Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of failed KubeVirt virtual machine backups, including failures indicated in either condition reason or message.
  * DataUpload failure reporting now uses the most informative available condition text, even when the message field is empty.
  * Enhanced failure handling for both completed (Done) and in-progress (not Done) backup states, with clearer failure details surfaced to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->